### PR TITLE
Changes to front page stats

### DIFF
--- a/docs/Queries.md
+++ b/docs/Queries.md
@@ -10,11 +10,11 @@ The query to get the banner stats is as follows:
 ```graphql
 {
   totalContributors
-  lastWeekContributors
+  lastMonthContributors
   totalGitPOAPs
-  lastWeekGitPOAPs
+  lastMonthGitPOAPs
   totalRepos
-  lastWeekRepos
+  lastMonthRepos
 }
 ```
 
@@ -24,11 +24,11 @@ and returns data in the form:
 {
   "data": {
     "totalContributors": 5,
-    "lastWeekContributors": 4,
+    "lastMonthContributors": 4,
     "totalGitPOAPs": 3,
-    "lastWeekGitPOAPs": 2,
+    "lastMonthGitPOAPs": 2,
     "totalRepos": 3,
-    "lastWeekRepos": 2
+    "lastMonthRepos": 2
   }
 }
 ```

--- a/src/graphql/resolvers/gitpoaps.ts
+++ b/src/graphql/resolvers/gitpoaps.ts
@@ -1,6 +1,6 @@
 import { Arg, Ctx, Field, ObjectType, Resolver, Query } from 'type-graphql';
 import { Claim, ClaimStatus, GitPOAP } from '@generated/type-graphql';
-import { getLastWeekStartDatetime } from './util';
+import { getLastMonthStartDatetime } from './util';
 import { Context } from '../../context';
 import { POAPEvent, POAPToken } from '../types/poap';
 import { resolveENS } from '../../util';
@@ -60,13 +60,13 @@ export class CustomGitPOAPResolver {
   }
 
   @Query(returns => Number)
-  async lastWeekGitPOAPs(@Ctx() { prisma }: Context): Promise<Number> {
+  async lastMonthGitPOAPs(@Ctx() { prisma }: Context): Promise<Number> {
     const result = await prisma.gitPOAP.aggregate({
       _count: {
         id: true,
       },
       where: {
-        createdAt: { gt: getLastWeekStartDatetime() },
+        createdAt: { gt: getLastMonthStartDatetime() },
       },
     });
     return result._count.id;

--- a/src/graphql/resolvers/repos.ts
+++ b/src/graphql/resolvers/repos.ts
@@ -1,6 +1,6 @@
 import { Arg, Ctx, Resolver, Query } from 'type-graphql';
 import { Repo } from '@generated/type-graphql';
-import { getLastWeekStartDatetime } from './util';
+import { getLastMonthStartDatetime } from './util';
 import { Context } from '../../context';
 
 @Resolver(of => Repo)
@@ -12,13 +12,13 @@ export class CustomRepoResolver {
   }
 
   @Query(returns => Number)
-  async lastWeekRepos(@Ctx() { prisma }: Context): Promise<Number> {
+  async lastMonthRepos(@Ctx() { prisma }: Context): Promise<Number> {
     const result = await prisma.repo.aggregate({
       _count: {
         id: true,
       },
       where: {
-        createdAt: { gt: getLastWeekStartDatetime() },
+        createdAt: { gt: getLastMonthStartDatetime() },
       },
     });
     return result._count.id;

--- a/src/graphql/resolvers/users.ts
+++ b/src/graphql/resolvers/users.ts
@@ -1,6 +1,6 @@
 import { Arg, Ctx, Field, ObjectType, Resolver, Query } from 'type-graphql';
 import { ClaimStatus, User } from '@generated/type-graphql';
-import { getLastWeekStartDatetime } from './util';
+import { getLastMonthStartDatetime } from './util';
 import { Context } from '../../context';
 
 @ObjectType()
@@ -21,13 +21,13 @@ export class CustomUserResolver {
   }
 
   @Query(returns => Number)
-  async lastWeekContributors(@Ctx() { prisma }: Context): Promise<Number> {
+  async lastMonthContributors(@Ctx() { prisma }: Context): Promise<Number> {
     const result = await prisma.user.aggregate({
       _count: {
         id: true,
       },
       where: {
-        createdAt: { gt: getLastWeekStartDatetime() },
+        createdAt: { gt: getLastMonthStartDatetime() },
       },
     });
     return result._count.id;

--- a/src/graphql/resolvers/util.ts
+++ b/src/graphql/resolvers/util.ts
@@ -1,10 +1,10 @@
 import { DateTime } from 'luxon';
 
-export function getLastWeekStartDay(): string {
-  const lastWeek = DateTime.now().minus({ days: 7 });
-  return lastWeek.toFormat('yyyy-MM-dd');
+export function getLastMonthStartDay(): string {
+  const lastMonth = DateTime.now().minus({ days: 30 });
+  return lastMonth.toFormat('yyyy-MM-dd');
 }
 
-export function getLastWeekStartDatetime(): Date {
-  return new Date(getLastWeekStartDay());
+export function getLastMonthStartDatetime(): Date {
+  return new Date(getLastMonthStartDay());
 }


### PR DESCRIPTION
https://www.notion.so/gitpoap/Frontend-Change-all-stats-to-all-time-stats-536cd878ffd64cf1a4befce31fcb1c81

Frontend Changes:
- `BannerStats` will show monthly difference instead of weekly.
- Leaderboard will show all time stats
- Most claimed will show all time stats

Backend Changes:
lastWeekContributors -> lastMonthContributors
lastWeekGitPOAPs -> lastMonthGitPOAPs
lastWeekRepos-> lastMonthRepos
lastWeekMostHonoredContributors -> mostHonoredContributors

getLastWeekStartDay -> getLastMonthStartDay
getLastWeekStartDatetime -> getLastMonthStartDatetime
