### PR TITLE
Add back generated routes due to breaks

### DIFF
--- a/prisma/factories.ts
+++ b/prisma/factories.ts
@@ -161,5 +161,3 @@ export class ProfileFactory {
     return profile;
   };
 }
-
-// export class FeaturedPOAPFac

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -1,5 +1,5 @@
 import { buildSchema, NonEmptyArray } from 'type-graphql';
-/* Don't export generated resolvers for now
+/* Don't export generated resolvers for now */
 import {
   UserCrudResolver,
   UserRelationsResolver,
@@ -16,7 +16,7 @@ import {
   FeaturedPOAPCrudResolver,
   FeaturedPOAPRelationsResolver,
 } from '@generated/type-graphql';
-*/
+
 import { CustomClaimResolver } from './resolvers/claims';
 import { CustomGitPOAPResolver } from './resolvers/gitpoaps';
 import { CustomProfileResolver } from './resolvers/profiles';
@@ -25,7 +25,7 @@ import { CustomSearchResolver } from './resolvers/search';
 import { CustomUserResolver } from './resolvers/users';
 
 const allResolvers: NonEmptyArray<Function> = [
-  /* Don't export generated resolvers for now
+  /* Don't export generated resolvers for now */
   // Generated resolvers
   UserCrudResolver,
   UserRelationsResolver,
@@ -41,7 +41,7 @@ const allResolvers: NonEmptyArray<Function> = [
   GitPOAPRelationsResolver,
   FeaturedPOAPCrudResolver,
   FeaturedPOAPRelationsResolver,
-*/
+
   // Custom resolvers
   CustomClaimResolver,
   CustomGitPOAPResolver,


### PR DESCRIPTION
A few queries were breaking due to the removal of the gen routes -> we should explore more re what's going on. 

Ex: 
```gql
{
  gitPOAPEvent(id: 1) {
      gitPOAP {
        id
        repo {
          organization{
            name
          }
        }
      }
      event {
        name
        image_url
        description
      }
    }
```

would return 

```json
{
  "errors": [
    {
      "message": "Cannot query field \"repo\" on type \"GitPOAP\". Did you mean \"repoId\"?",
      "locations": [
        {
          "line": 35,
          "column": 9
        }
      ]
    }
  ]
}
```


when it should return

```json
{
  "data": {
    "gitPOAPEvent": {
      "gitPOAP": {
        "id": 1,
        "repo": {
          "organization": {
            "name": "org43"
          }
        }
      },
      "event": {
        "name": "Welcome to the Thunderdome",
        "image_url": "https://avatars.githubusercontent.com/u/1555326?v=4",
        "description": "Wow, you survived.\nGreat"
      }
    }
  }
}
```