### PR TITLE
Clear a user's POAP cache after they claim

### DIFF
--- a/src/external/poap.ts
+++ b/src/external/poap.ts
@@ -256,6 +256,11 @@ export async function retrieveUsersPOAPs(address: string) {
   return poapResponse;
 }
 
+// Helper function to clear a user's POAPs from the cache
+export async function clearUsersPOAPsCache(address: string) {
+  await context.redis.deleteKey(POAP_USER_TOKENS_CACHE_PREFIX, address);
+}
+
 export async function retrievePOAPInfo(poapTokenId: string) {
   const logger = createScopedLogger('retrievePOAPInfo');
 

--- a/src/routes/claims.ts
+++ b/src/routes/claims.ts
@@ -8,7 +8,12 @@ import { isSignatureValid } from '../signatures';
 import jwt from 'express-jwt';
 import { jwtWithAdminOAuth } from '../middleware';
 import { AccessTokenPayload, AccessTokenPayloadWithOAuth } from '../types/tokens';
-import { redeemPOAP, requestPOAPCodes, retrievePOAPEventInfo } from '../external/poap';
+import {
+  clearUsersPOAPsCache,
+  redeemPOAP,
+  requestPOAPCodes,
+  retrievePOAPEventInfo,
+} from '../external/poap';
 import { getGithubUserById } from '../external/github';
 import { JWT_SECRET } from '../environment';
 import { createScopedLogger } from '../logging';
@@ -253,6 +258,8 @@ claimsRouter.post(
     logger.debug(
       `Completed request claiming IDs ${req.body.claimIds} for address ${req.body.address}`,
     );
+
+    clearUsersPOAPsCache(req.body.address);
 
     res.status(200).send({
       claimed: foundClaims,


### PR DESCRIPTION
After a user has made a claim, we expect that the (Git)POAP will show up in their profile.

This PR makes the changes necessary to clear out the cache after the claim, but we should think about this. The issue may be that after clearing the cache, the POAP API still hasn't finished minting the POAP so it will not show up in the user's POAPs that we newly cache, and then the user will have to wait another minute for the cache to clear out the key (1 min TTL).

On the other hand if we don't make these changes the user will have to wait at most 1 min before their listing gets updated (assuming POAP is done by that point).

Thoughts? @jaypb1 