### PR TITLE
Remove access token payload printout on single endpoint

### DIFF
--- a/src/routes/claims.ts
+++ b/src/routes/claims.ts
@@ -145,8 +145,6 @@ claimsRouter.post(
       return res.status(401).send({ message: 'Invalid or missing Access Token' });
     }
 
-    logger.debug(`Access Token Payload: ${req.user}`);
-
     const schemaResult = ClaimGitPOAPSchema.safeParse(req.body);
     if (!schemaResult.success) {
       logger.warn(


### PR DESCRIPTION
We don't do this in any other requests