### PR TITLE
Add minting GitPOAPs as separate field on userPOAPs query

### DIFF
--- a/src/graphql/resolvers/gitpoaps.ts
+++ b/src/graphql/resolvers/gitpoaps.ts
@@ -278,7 +278,7 @@ export class CustomGitPOAPResolver {
     const mintingClaims: Claim[] = claims.filter(claim => claim.status === ClaimStatus.MINTING);
     let mintingGitPOAPs = [];
     for (const claim of mintingClaims) {
-      if (claim.gitPOAP?.poapEventId) {
+      if (claim.gitPOAP) {
         const event = await retrievePOAPEventInfo(claim.gitPOAP.poapEventId);
         if (event !== null) {
           mintingGitPOAPs.push({


### PR DESCRIPTION
**Summary:** 
- Add `mintingGitPOAPs` as a field on the `userPOAPs` Query. 

Is this the best approach? Ideally, the 'minting' gitPOAPs should be part of the `gitPOAPs` list in the returned object. 

@burz - thoughts? 