### PR TITLE
The ongoing issuance should go through updated dates in descending order

### DIFF
--- a/src/external/github.ts
+++ b/src/external/github.ts
@@ -151,6 +151,6 @@ export async function getRepositoryPullsAsAdmin(
   page: number,
 ) {
   return await makeAdminGithubAPIRequest(
-    `/repos/${org}/${repo}/pulls?state=closed&sort=updated&per_page=${perPage}&page=${page}`,
+    `/repos/${org}/${repo}/pulls?state=closed&sort=updated&direction=desc&per_page=${perPage}&page=${page}`,
   );
 }


### PR DESCRIPTION
I noticed looking at the DB that it was running through the PRs in the wrong direction. This is not an issue from the perspective of actually creating claims, but we are requesting more data than necessary and hitting the db more than necessary, which could be problematic as we grow in number of repos.

See: https://docs.github.com/en/rest/pulls/pulls#list-pull-requests
Namely: "Default: `desc` when sort is `created` or sort is not specified, otherwise `asc`."