### PR TITLE
Fix issue with DB migrations where I accidentally removed an old migration

### DIFF
--- a/prisma/migrations/20220525035411_add_table_for_github_pr_data/migration.sql
+++ b/prisma/migrations/20220525035411_add_table_for_github_pr_data/migration.sql
@@ -12,7 +12,6 @@ CREATE TABLE "GithubPullRequest" (
     "githubPullNumber" INTEGER NOT NULL,
     "githubTitle" TEXT NOT NULL,
     "githubMergedAt" TIMESTAMP(3) NOT NULL,
-    "githubMergeCommitSha" VARCHAR(41) NOT NULL,
     "repoId" INTEGER NOT NULL,
     "userId" INTEGER NOT NULL,
 

--- a/prisma/migrations/20220601162411_add_github_merge_commit_sha/migration.sql
+++ b/prisma/migrations/20220601162411_add_github_merge_commit_sha/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `githubMergeCommitSha` to the `GithubPullRequest` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "GitPOAP" ALTER COLUMN "lastPRUpdatedAt" SET DEFAULT date_trunc('year', now());
+
+-- AlterTable
+ALTER TABLE "GithubPullRequest" ADD COLUMN     "githubMergeCommitSha" VARCHAR(41) NOT NULL;


### PR DESCRIPTION
I had gotten in the habit of flattening migrations from a single PR, i.e. if I had created two individual migrations in the same PR, I would remove them and let `prisma` recreate them as a single migration (seemed more clean).

Unfortunately during the course of https://github.com/gitpoap/gitpoap-backend/pull/145, I mistakenly believed that the previously merged migration `prisma/migrations/20220525035411_add_table_for_github_pr_data/migration.sql` was from that PR, and consolidated it into `prisma/migrations/20220531191328_add_table_for_github_pr_data/migration.sql` when I added the new column `githubMergeCommitSha`.

This caused an issue with our deployment to staging since the migration process tried to recreate some columns that had previously been created: [CloudWatch logs for the db-migrator](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fgitpoap-migration-staging-lambda/log-events/2022$252F06$252F01$252F$255B$2524LATEST$255D2954358378ec4c209cabb8f656152075)

To fix this, I checked out the old version of the migration and reran the migration process so a new migration would be created that contained the new column `githubMergeCommitSha` on its own.