### PR TITLE
Make githubMergeCommitSha non-nullable

### DIFF
--- a/prisma/migrations/20220601175035_make_github_merge_commit_sha_non_nullable/migration.sql
+++ b/prisma/migrations/20220601175035_make_github_merge_commit_sha_non_nullable/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Made the column `githubMergeCommitSha` on table `GithubPullRequest` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "GitPOAP" ALTER COLUMN "lastPRUpdatedAt" SET DEFAULT date_trunc('year', now());
+
+-- AlterTable
+ALTER TABLE "GithubPullRequest" ALTER COLUMN "githubMergeCommitSha" SET NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -168,7 +168,7 @@ model GithubPullRequest {
   githubPullNumber     Int
   githubTitle          String
   githubMergedAt       DateTime
-  githubMergeCommitSha String?  @db.VarChar(41)
+  githubMergeCommitSha String   @db.VarChar(41)
   repoId               Int
   repo                 Repo     @relation(fields: [repoId], references: [id])
   userId               Int

--- a/schema.gql
+++ b/schema.gql
@@ -414,7 +414,7 @@ type GithubPullRequest {
   ): [Claim!]!
   _count: GithubPullRequestCount
   createdAt: DateTime!
-  githubMergeCommitSha: String
+  githubMergeCommitSha: String!
   githubMergedAt: DateTime!
   githubPullNumber: Int!
   githubTitle: String!
@@ -483,7 +483,7 @@ input GithubPullRequestWhereInput {
   NOT: [GithubPullRequestWhereInput!]
   OR: [GithubPullRequestWhereInput!]
   createdAt: DateTimeFilter
-  githubMergeCommitSha: StringNullableFilter
+  githubMergeCommitSha: StringFilter
   githubMergedAt: DateTimeFilter
   githubPullNumber: IntFilter
   githubTitle: StringFilter


### PR DESCRIPTION
Now that we've filled out the `githubMergeCommitSha` column on each `GithubPullRequest` record via the backloader, now we can make this column non-null.