### PR TITLE
Fix issue related to rare PRs

### DIFF
--- a/src/external/github.ts
+++ b/src/external/github.ts
@@ -202,6 +202,9 @@ export type GithubPullRequestData = {
   merged_at: string;
   updated_at: string;
   merge_commit_sha: string;
+  head: {
+    sha: string;
+  };
 };
 
 // This should only be used for our background processes

--- a/src/lib/ongoing.ts
+++ b/src/lib/ongoing.ts
@@ -8,6 +8,7 @@ import {
   ongoingIssuanceProjectDurationSeconds,
   overallOngoingIssuanceDurationSeconds,
 } from '../metrics';
+import { extractMergeCommitSha } from './pullRequests';
 
 // The number of pull requests to request in a single page (currently the maximum number)
 const PULL_STEP_SIZE = 100;
@@ -112,7 +113,7 @@ export async function checkForNewContributions(gitPOAP: GitPOAPReturnType) {
           githubPullNumber: pull.number,
           githubTitle: pull.title,
           githubMergedAt: new Date(pull.merged_at),
-          githubMergeCommitSha: pull.merge_commit_sha,
+          githubMergeCommitSha: extractMergeCommitSha(pull),
           repo: {
             connect: {
               id: gitPOAP.repo.id,


### PR DESCRIPTION
On PROD, I found 2 PRs where there was no `merge_commit_sha` returned by the API (out of 18k+ PRs). In this case GitHub shows that the final commit (i.e. the "head") was merged into the main branch.

This PR handles this rare case (I fixed this manually for the backloader before looking into this).

Ex: https://gist.github.com/burz/0ed337a6a0eb77544f965a587623a0a5
For PR: https://github.com/ethereumjs/ethereumjs-monorepo/pull/32
You can see that `pr.head.sha` is the same as what GitHub reports as merged into `master`