### PR TITLE
Update RepoData to include gitPOAPsMintedCount

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -138,13 +138,13 @@ async function main() {
   const claim8D = await ClaimFactory.createClaim(gitpoap8.id, aldo.id);
 
   const claim9A = await ClaimFactory.createClaim(gitpoap9.id, jay.id);
-  const claim9B = await ClaimFactory.createClaim(gitpoap9.id, anthony.id);
-  const claim9C = await ClaimFactory.createClaim(gitpoap9.id, colfax.id);
+  const claim9B = await ClaimFactory.createClaim(gitpoap9.id, anthony.id, ClaimStatus.CLAIMED, ADDRESSES.anthony, '1234567891', new Date(2020, 1, 9));
+  const claim9C = await ClaimFactory.createClaim(gitpoap9.id, colfax.id, ClaimStatus.CLAIMED, ADDRESSES.colfax, '1234567892', new Date(2020, 1, 9));
   const claim9D = await ClaimFactory.createClaim(gitpoap9.id, aldo.id);
 
   const claim10A = await ClaimFactory.createClaim(gitpoap10.id, jay.id);
   const claim10B = await ClaimFactory.createClaim(gitpoap10.id, anthony.id);
-  const claim10C = await ClaimFactory.createClaim(gitpoap10.id, colfax.id);
+  const claim10C = await ClaimFactory.createClaim(gitpoap10.id, colfax.id, ClaimStatus.CLAIMED, ADDRESSES.colfax, '1234567893', new Date(2020, 1, 9));
   const claim10D = await ClaimFactory.createClaim(gitpoap10.id, aldo.id);
 
   const claim11A = await ClaimFactory.createClaim(gitpoap11.id, jay.id);

--- a/src/graphql/resolvers/repos.ts
+++ b/src/graphql/resolvers/repos.ts
@@ -10,6 +10,8 @@ import { getGithubRepositoryStarCount } from '../../external/github';
 class RepoData extends Repo {
   @Field()
   contributorCount: number;
+  @Field()
+  mintedGitPOAPCount: number;
 }
 
 @Resolver(of => Repo)
@@ -26,7 +28,7 @@ export class CustomRepoResolver {
     const endTimer = gqlRequestDurationSeconds.startTimer('repoData');
 
     const results = await prisma.$queryRaw<RepoData[]>`
-      SELECT r.*, COUNT(c.id) AS "contributorCount"
+      SELECT r.*, COUNT(DISTINCT c."userId") AS "contributorCount", COUNT(c.id) AS "mintedGitPOAPCount"
       FROM "Repo" as r
       INNER JOIN "GitPOAP" AS g ON g."repoId" = r.id
       INNER JOIN "Claim" AS c ON c."gitPOAPId" = g.id


### PR DESCRIPTION
Fix `contributorCount` on repoData Query, which was actually returning the number of gitPOAPs that had been minted
Add `mintedGitPOAPCount` on repoDataQuery
Update seed to make testing easier

Open to renaming `mintedGitPOAPCount` to something simpler such as `mintedCount`