### PR TITLE
Merge in temporary fix for User upserts

### DIFF
--- a/src/lib/ongoing.ts
+++ b/src/lib/ongoing.ts
@@ -9,6 +9,7 @@ import {
   overallOngoingIssuanceDurationSeconds,
 } from '../metrics';
 import { extractMergeCommitSha } from './pullRequests';
+import { upsertUser } from './users';
 
 // The number of pull requests to request in a single page (currently the maximum number)
 const PULL_STEP_SIZE = 100;
@@ -85,18 +86,7 @@ export async function checkForNewContributions(gitPOAP: GitPOAPReturnType) {
       logger.info(`Creating a claim for ${pull.user.login} if it doesn't exist`);
 
       // Create the User, GithubPullRequest, and Claim if they don't exist
-      const user = await context.prisma.user.upsert({
-        where: {
-          githubId: pull.user.id,
-        },
-        update: {
-          githubHandle: pull.user.login,
-        },
-        create: {
-          githubId: pull.user.id,
-          githubHandle: pull.user.login,
-        },
-      });
+      const user = await upsertUser(pull.user.id, pull.user.login);
 
       const githubPullRequest = await context.prisma.githubPullRequest.upsert({
         where: {

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -1,0 +1,42 @@
+import { context } from '../context';
+import { User } from '@generated/type-graphql';
+import { createScopedLogger } from '../logging';
+
+// Temporarily wrap the upserts in a try-catch while
+// we have an issue open in the prisma repo
+export async function upsertUser(id: number, handle: string): Promise<User> {
+  const logger = createScopedLogger('upsertUser');
+
+  logger.info(`Attempting to upsert GitHub user ${handle}`);
+
+  try {
+    return await context.prisma.user.upsert({
+      where: {
+        githubId: id,
+      },
+      update: {
+        githubHandle: handle,
+      },
+      create: {
+        githubId: id,
+        githubHandle: handle,
+      },
+    });
+  } catch (err) {
+    logger.warn(`Caught error: ${err}`);
+
+    const user = await context.prisma.user.findUnique({
+      where: {
+        githubId: id,
+      },
+    });
+
+    if (user === null) {
+      const msg = `Failed to upsert GitHub user ${handle} but the user doesn't exist!`;
+      logger.error(msg);
+      throw Error(msg);
+    }
+
+    return user;
+  }
+}

--- a/src/routes/claims.ts
+++ b/src/routes/claims.ts
@@ -16,6 +16,7 @@ import { httpRequestDurationSeconds } from '../metrics';
 import { DateTime } from 'luxon';
 import { sleep } from '../lib/sleep';
 import { backloadGithubPullRequestData } from '../lib/pullRequests';
+import { upsertUser } from '../lib/users';
 
 export const claimsRouter = Router();
 
@@ -389,18 +390,7 @@ claimsRouter.post('/create', jwtWithAdminOAuth(), async function (req, res) {
 
     // Ensure that we've created a user in our
     // system for the claim
-    const user = await context.prisma.user.upsert({
-      where: {
-        githubId: githubId,
-      },
-      update: {
-        githubHandle: githubUserInfo.login,
-      },
-      create: {
-        githubId: githubId,
-        githubHandle: githubUserInfo.login,
-      },
-    });
+    const user = await upsertUser(githubId, githubUserInfo.login);
 
     await context.prisma.claim.create({
       data: {

--- a/src/routes/github.ts
+++ b/src/routes/github.ts
@@ -10,6 +10,7 @@ import { requestGithubOAuthToken, getGithubCurrentUserInfo } from '../external/g
 import { JWT_SECRET } from '../environment';
 import { createScopedLogger } from '../logging';
 import { httpRequestDurationSeconds } from '../metrics';
+import { upsertUser } from '../lib/users';
 
 export const githubRouter = Router();
 
@@ -71,18 +72,7 @@ githubRouter.post('/', async function (req, res) {
   }
 
   // Update or create the user's data
-  const user = await context.prisma.user.upsert({
-    where: {
-      githubId: githubUser.id,
-    },
-    update: {
-      githubHandle: githubUser.login,
-    },
-    create: {
-      githubId: githubUser.id,
-      githubHandle: githubUser.login,
-    },
-  });
+  const user = await upsertUser(githubUser.id, githubUser.login);
 
   const authToken = await context.prisma.authToken.create({
     data: {


### PR DESCRIPTION
I will rerun the backloader script after this on PROD so that we don't miss the (failed) backloading for `rotki/rotki` and `ethereum-cat-herders/PM`, but I think you are right about the `Promise.all` being the problem -- will explore this tomorrow.