### PR TITLE
Replace Inner Join with Left Join for organizationData Query

### DIFF
--- a/src/graphql/resolvers/organizations.ts
+++ b/src/graphql/resolvers/organizations.ts
@@ -173,16 +173,11 @@ export class CustomOrganizationResolver {
       : Prisma.empty;
 
     const results = await prisma.$queryRaw<RepoData[]>`
-      SELECT r.*, 
-        COUNT(DISTINCT c."userId") AS "contributorCount",
-        COUNT(c.id) AS "mintedGitPOAPCount"
+      SELECT r.*, COUNT(DISTINCT c."userId") AS "contributorCount", COUNT(c.id) AS "mintedGitPOAPCount"
       FROM "Repo" as r
       INNER JOIN "GitPOAP" AS g ON g."repoId" = r.id
-      LEFT JOIN 
-        (SELECT * 
-          FROM "Claim" 
-          WHERE status = ${ClaimStatus.CLAIMED}) AS c ON c."gitPOAPId" = g.id
-      WHERE r."organizationId" = ${orgId}
+      INNER JOIN "Claim" AS c ON c."gitPOAPId" = g.id
+      WHERE r."organizationId" = ${orgId} AND c.status = ${ClaimStatus.CLAIMED}
       GROUP BY r.id
       ORDER BY ${orderBy}
       ${pagination}

--- a/src/graphql/resolvers/repos.ts
+++ b/src/graphql/resolvers/repos.ts
@@ -33,16 +33,11 @@ export class CustomRepoResolver {
 
     if (repoId) {
       results = await prisma.$queryRaw<RepoData[]>`
-        SELECT r.*, 
-          COUNT(DISTINCT c."userId") AS "contributorCount",
-          COUNT(c.id) AS "mintedGitPOAPCount"
+        SELECT r.*, COUNT(DISTINCT c."userId") AS "contributorCount", COUNT(c.id) AS "mintedGitPOAPCount"
         FROM "Repo" as r
         INNER JOIN "GitPOAP" AS g ON g."repoId" = r.id
-        LEFT JOIN 
-          (SELECT * 
-            FROM "Claim" 
-            WHERE status = ${ClaimStatus.CLAIMED}) AS c ON c."gitPOAPId" = g.id
-        WHERE r.id = ${repoId}
+        INNER JOIN "Claim" AS c ON c."gitPOAPId" = g.id
+        WHERE r.id = ${repoId} AND c.status = ${ClaimStatus.CLAIMED}
         GROUP BY r.id
       `;
 
@@ -55,17 +50,12 @@ export class CustomRepoResolver {
       logger.debug(`Completed request for data from repo: ${repoId}`);
     } else if (orgName && repoName) {
       results = await prisma.$queryRaw<RepoData[]>`
-        SELECT r.*, 
-          COUNT(DISTINCT c."userId") AS "contributorCount",
-          COUNT(c.id) AS "mintedGitPOAPCount"
+        SELECT r.*, COUNT(DISTINCT c."userId") AS "contributorCount", COUNT(c.id) AS "mintedGitPOAPCount"
         FROM "Repo" as r
         INNER JOIN "Organization" AS o ON o.id = r."organizationId"
         INNER JOIN "GitPOAP" AS g ON g."repoId" = r.id
-        LEFT JOIN 
-          (SELECT * 
-            FROM "Claim" 
-            WHERE status = ${ClaimStatus.CLAIMED}) AS c ON c."gitPOAPId" = g.id
-        WHERE o.name = ${orgName} AND r.name = ${repoName}
+        INNER JOIN "Claim" AS c ON c."gitPOAPId" = g.id
+        WHERE o.name = ${orgName} AND r.name = ${repoName} AND c.status = ${ClaimStatus.CLAIMED}
         GROUP BY r.id
       `;
 


### PR DESCRIPTION
Fixes all queries that return `gitPOAPCount` and `mintedGitPOAPCount` by replacing the `inner join` of the claim table with a `left join` subquery. The old implementation was not including gitPOAPs that had yet to be minted
https://dataschool.com/how-to-teach-people-sql/sql-join-types-explained-visually/

Nothing on the site is currently broken because of this change, due to the organization page not being released