### PR TITLE
Fix location of where clause for ongoing relation selects

### DIFF
--- a/src/lib/ongoing.ts
+++ b/src/lib/ongoing.ts
@@ -174,18 +174,14 @@ async function runOngoingIssuanceUpdater() {
   const endTimer = overallOngoingIssuanceDurationSeconds.startTimer();
 
   const repos: RepoReturnType[] = await context.prisma.repo.findMany({
-    where: {
-      gitPOAPs: {
-        every: {
-          ongoing: true,
-        },
-      },
-    },
     select: {
       id: true,
       name: true,
       lastPRUpdatedAt: true,
       gitPOAPs: {
+        where: {
+          ongoing: true,
+        },
         select: {
           id: true,
           year: true,

--- a/src/lib/pullRequests.ts
+++ b/src/lib/pullRequests.ts
@@ -12,11 +12,6 @@ async function getRepoInfo(repoId: number) {
   const result = await context.prisma.repo.findMany({
     where: {
       id: repoId,
-      gitPOAPs: {
-        every: {
-          ongoing: true,
-        },
-      },
     },
     select: {
       id: true,
@@ -27,6 +22,9 @@ async function getRepoInfo(repoId: number) {
         },
       },
       gitPOAPs: {
+        where: {
+          ongoing: true,
+        },
         select: {
           id: true,
           year: true,

--- a/src/lib/repos.ts
+++ b/src/lib/repos.ts
@@ -11,15 +11,13 @@ export async function getRepoByName(owner: string, repo: string): Promise<RepoDa
       organization: {
         name: owner,
       },
-      gitPOAPs: {
-        every: {
-          ongoing: true,
-        },
-      },
     },
     select: {
       id: true,
       gitPOAPs: {
+        where: {
+          ongoing: true,
+        },
         select: {
           id: true,
           year: true,


### PR DESCRIPTION
While running the pr-backloader I noticed that these queries was not functioning correctly since it was only returning repos where only a single ongoing GitPOAP where in the relation. Will need to roll out to PROD