### PR TITLE
Automatically embed link within generated GH badge

### DIFF
--- a/src/public-api/v1.ts
+++ b/src/public-api/v1.ts
@@ -195,12 +195,6 @@ v1Router.get('/repo/:owner/:name/badge', async (req, res) => {
   const repo = await context.prisma.repo.findFirst({
     select: {
       id: true,
-      name: true,
-      organization: {
-        select: {
-          name: true,
-        },
-      },
     },
     where: {
       organization: {


### PR DESCRIPTION
Summary: 
- Changes that embed an anchor (`<a>`) tag hyperlink to the gitpoap repo page for a respective repo within it's automatically generated GH badge. 


i.e. The following URLs should return badges that have embedded hyperlinks
1. http://localhost:3122/v1/repo/gitpoap/gitpoap-fe/badge
2. https://public-api.gitpoap.io/v1/repo/ethereum/ethereum-org-website/badge (once deployed)