### PR TITLE
Catch around individual repos in ongoing issuance

### DIFF
--- a/src/lib/ongoing.ts
+++ b/src/lib/ongoing.ts
@@ -208,7 +208,11 @@ async function runOngoingIssuanceUpdater() {
       await sleep(DELAY_BETWEEN_ONGOING_ISSUANCE_CHECKS_SECONDS);
     }
 
-    await checkForNewContributions(repos[i]);
+    try {
+      await checkForNewContributions(repos[i]);
+    } catch (err) {
+      logger.error(`Failed to run the ongoing issuance process for Repo ID ${repos[i]}: ${err}`);
+    }
   }
 
   endTimer({ processed_count: repos.length });


### PR DESCRIPTION
We were getting an error for an individual repo that prevents the rest of the ongoing issuance process from running (i.e. the remaining repos). Let's wrap the individual process with a `try` as well so we can log the failing repo ID and continue onto the next projects