### PR TITLE
Switch to upsert in claims uploader route

### DIFF
--- a/src/routes/claims.ts
+++ b/src/routes/claims.ts
@@ -403,8 +403,16 @@ claimsRouter.post('/create', jwtWithAdminOAuth(), async function (req, res) {
     // system for the claim
     const user = await upsertUser(githubId, githubUserInfo.login);
 
-    await context.prisma.claim.create({
-      data: {
+    // Upsert so we can rerun the script if necessary
+    await context.prisma.claim.upsert({
+      where: {
+        gitPOAPId_userId: {
+          gitPOAPId: gitPOAPData.id,
+          userId: user.id,
+        },
+      },
+      update: {},
+      create: {
         gitPOAP: {
           connect: {
             id: gitPOAPData.id,


### PR DESCRIPTION
This should fix the issue that @nixorokish was running into. So we should now be able to run the upload claims script multiple times if neccessary (for instance if the server restarts/goes down in the midst of the upload).

@colfax23 