### PR TITLE
Copy postgresql canonical representation to fix repeating migration issue

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -70,7 +70,7 @@ model Repo {
   GithubPullRequest GithubPullRequest[]
   // Default to the beginning of the year, but this will update when contributions
   // are initially uploaded
-  lastPRUpdatedAt   DateTime            @default(dbgenerated("date_trunc('year', now())"))
+  lastPRUpdatedAt   DateTime            @default(dbgenerated("date_trunc('year'::text, now())"))
 }
 
 model Claim {


### PR DESCRIPTION
I got notified of [this new comment](https://github.com/prisma/prisma/issues/9823#issuecomment-1177686869) on the issue I'm following for the repeated migration issue related to the default for `lastPRUpdatedAt`. Following the process outlined fixes the issue!