### PR TITLE
Public API needs INSERT and SELECT on Secret table for POAP API

### DIFF
--- a/.dockerfiles/readonly-db-setup.sh
+++ b/.dockerfiles/readonly-db-setup.sh
@@ -18,6 +18,7 @@ GRANT SELECT ON "Profile" TO $READONLY_USER;
 GRANT SELECT ON "Repo" TO $READONLY_USER;
 GRANT SELECT ON "User" TO $READONLY_USER;
 GRANT SELECT ON "Project" TO $READONLY_USER;
--- We need to expose Secret so the public API can interface with POAP
-GRANT SELECT ON "Secret" TO $READONLY_USER;
+-- We need to expose more on Secret so the public API can interface with POAP
+GRANT SELECT, INSERT, UPDATE ON "Secret" TO $READONLY_USER;
+GRANT USAGE, SELECT ON SEQUENCE "Secret_id_seq" TO $READONLY_USER;
 EOF

--- a/docs/Read-Only-DB-User.md
+++ b/docs/Read-Only-DB-User.md
@@ -26,6 +26,7 @@ GRANT SELECT ON "Profile" TO <Your-User>;
 GRANT SELECT ON "Repo" TO <Your-User>;
 GRANT SELECT ON "User" TO <Your-User>;
 GRANT SELECT ON "Project" TO <Your-User>;
--- We need to expose Secret so the public API can interface with POAP
-GRANT SELECT ON "Secret" TO <Your-User>;
+-- We need to expose more on Secret so the public API can interface with POAP
+GRANT SELECT, INSERT, UPDATE ON "Secret" TO <Your-User>;
+GRANT USAGE, SELECT ON SEQUENCE "Secret_id_seq" TO <Your-User>;
 ```


### PR DESCRIPTION
If the public API is the first to call POAP after the secret expires, it needs to be able to update the secret