### PR TITLE
Ensure that counted claims are distinct for mintedGitPOAPCount

### DIFF
--- a/src/graphql/resolvers/organizations.ts
+++ b/src/graphql/resolvers/organizations.ts
@@ -46,7 +46,7 @@ export class CustomOrganizationResolver {
       SELECT o.*,
         COUNT(DISTINCT c."userId") AS "contributorCount",
         COUNT(DISTINCT g.id) AS "gitPOAPCount",
-        COUNT(c.id) AS "mintedGitPOAPCount",
+        COUNT(DISTINCT c.id) AS "mintedGitPOAPCount",
         COUNT(DISTINCT r.id) AS "repoCount"
       FROM "Organization" as o
       INNER JOIN "Repo" AS r ON r."organizationId" = o.id
@@ -177,7 +177,7 @@ export class CustomOrganizationResolver {
       SELECT r.*,
         COUNT(DISTINCT c."userId") AS "contributorCount",
         COUNT(DISTINCT g.id) AS "gitPOAPCount",
-        COUNT(c.id) AS "mintedGitPOAPCount"
+        COUNT(DISTINCT c.id) AS "mintedGitPOAPCount"
       FROM "Repo" as r
       INNER JOIN "Project" AS p ON p.id = r."projectId"
       INNER JOIN "GitPOAP" AS g ON g."projectId" = p.id


### PR DESCRIPTION
This issue happens when an organization has multiple repositories in the same organization.

I also looked into:
1. https://github.com/gitpoap/gitpoap-backend/blob/main/src/graphql/resolvers/repos.ts#L38-L50
2. https://github.com/gitpoap/gitpoap-backend/blob/main/src/graphql/resolvers/repos.ts#L62-L75

But it wouldn't occur there since it selects on only one Repo.