### PR TITLE
Small updates to migrator lambda Dockerfile

### DIFF
--- a/aws/db-migrator/Dockerfile
+++ b/aws/db-migrator/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM public.ecr.aws/lambda/provided:al2
 
-RUN yum install -y \
+RUN yum update -y && yum install -y \
   gcc-c++ \
   git \
   gzip \
@@ -24,7 +24,7 @@ RUN curl -L https://raw.githubusercontent.com/tj/n/master/bin/n -o n && \
   bash n lts && \
   rm n
 
-RUN npm install -g npm@8.10.0 yarn
+RUN npm install --location=global npm@8.10.0 yarn
 
 COPY cdk-lambda-bash/bootstrap /var/runtime/bootstrap
 COPY cdk-lambda-bash/function.sh /var/task/function.sh


### PR DESCRIPTION
Doesn't need to be rolled out, we can wait until it rolls out with something else.