### PR TITLE
Add action to rebase develop over main

### DIFF
--- a/.github/workflows/rebase-develop-over-main.yml
+++ b/.github/workflows/rebase-develop-over-main.yml
@@ -1,0 +1,26 @@
+# This workflow automatically rebases the "develop" branch over
+# "main" after "main" has new commits
+
+name: Rebase develop over main
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  run-rebase:
+    name: Run rebase
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Rebase develop over main
+        run: |
+          git fetch origin main
+          git fetch origin develop
+          git checkout develop
+          git rebase origin/main
+          git push -f


### PR DESCRIPTION
Here's an example run: https://github.com/gitpoap/gitpoap-backend/runs/7884488947?check_suite_focus=true

We may need to mess around with permissions to get the force push to work on the actions user, but I will debug once we get to a `develop` -> `main` merge.