### PR TITLE
Rollout fix for backloader 2022-08-19

### DIFF
--- a/__tests__/unit/src/lib/claims.ts
+++ b/__tests__/unit/src/lib/claims.ts
@@ -1,5 +1,5 @@
 import { contextMock } from '../../../../__mocks__/src/context';
-import { createNewClaimsForRepoPR, RepoData } from '../../../../src/lib/claims';
+import { createNewClaimsForRepoPRHelper, RepoData } from '../../../../src/lib/claims';
 
 const user = { id: 4 };
 const pr = { id: 32 };
@@ -50,7 +50,7 @@ describe('createNewClaimsForRepoPR', () => {
       },
     };
 
-    await createNewClaimsForRepoPR(user, repo, pr);
+    await createNewClaimsForRepoPRHelper(user, repo, pr);
 
     expect(contextMock.prisma.githubPullRequest.count).toHaveBeenCalledTimes(1);
 
@@ -73,7 +73,7 @@ describe('createNewClaimsForRepoPR', () => {
       },
     };
 
-    await createNewClaimsForRepoPR(user, repo, pr);
+    await createNewClaimsForRepoPRHelper(user, repo, pr);
 
     expect(contextMock.prisma.githubPullRequest.count).toHaveBeenCalledTimes(1);
 
@@ -109,7 +109,7 @@ describe('createNewClaimsForRepoPR', () => {
       },
     };
 
-    await createNewClaimsForRepoPR(user, repo, pr);
+    await createNewClaimsForRepoPRHelper(user, repo, pr);
 
     expect(contextMock.prisma.githubPullRequest.count).toHaveBeenCalledTimes(1);
 
@@ -143,7 +143,7 @@ describe('createNewClaimsForRepoPR', () => {
       },
     };
 
-    await createNewClaimsForRepoPR(user, repo, pr);
+    await createNewClaimsForRepoPRHelper(user, repo, pr);
 
     expect(contextMock.prisma.githubPullRequest.count).toHaveBeenCalledTimes(1);
 

--- a/src/routes/claims.ts
+++ b/src/routes/claims.ts
@@ -25,7 +25,7 @@ import {
   extractMergeCommitSha,
 } from '../lib/pullRequests';
 import { upsertUser } from '../lib/users';
-import { createNewClaimsForRepoPR, RepoData, retrieveClaimsCreatedByPR } from '../lib/claims';
+import { RepoData, createNewClaimsForRepoPRHelper, retrieveClaimsCreatedByPR } from '../lib/claims';
 import { getRepoByName } from '../lib/repos';
 
 export const claimsRouter = Router();
@@ -543,7 +543,7 @@ claimsRouter.post(
     );
 
     // Create any new claims (if they haven't been already)
-    await createNewClaimsForRepoPR(user, repo, githubPullRequest);
+    await createNewClaimsForRepoPRHelper(user, repo, githubPullRequest);
 
     const newClaims = await retrieveClaimsCreatedByPR(githubPullRequest.id);
 


### PR DESCRIPTION
Includes:
* https://github.com/gitpoap/gitpoap-backend/pull/271

I will trigger the backloader on the GitPOAP repos after this finishes rolling out.