### PR TITLE
Show more claim modal claims

### DIFF
--- a/src/graphql/resolvers/claims.ts
+++ b/src/graphql/resolvers/claims.ts
@@ -82,7 +82,9 @@ export class CustomClaimResolver {
         },
         OR: [
           {
-            status: ClaimStatus.UNCLAIMED,
+            status: {
+              in: [ClaimStatus.UNCLAIMED, ClaimStatus.PENDING, ClaimStatus.MINTING],
+            },
           },
           {
             mintedAt: { gt: getLastMonthStartDatetime() },
@@ -102,7 +104,7 @@ export class CustomClaimResolver {
       },
     });
 
-    let results: FullClaimData[] = [];
+    const results: FullClaimData[] = [];
 
     for (const claim of claims) {
       const { gitPOAP, ...claimData } = claim;


### PR DESCRIPTION
Summary: 
This PR increases the types of claims that are shown in the claim modal. When a user claims a claim, the record is switched into the `PENDING` and `MINTING` states, and after 20s or so, enters a `CLAIMED` state. 

We want to see all of these claims in the claim modal, hence the change found in this PR. 