### PR TITLE
Ensure that SVGs have a good default size

### DIFF
--- a/src/lib/ens.ts
+++ b/src/lib/ens.ts
@@ -9,9 +9,11 @@ const ENS_AVATAR_LAST_RUN_CACHE_PREFIX = 'ens#avatar-last-run';
 
 const ENS_AVATAR_MAX_CHECK_FREQUENCY_HOURS = 1;
 
+const DEFAULT_SVG_IMAGE_SIZE = 500;
+
 const contentTypeCallback: ContentTypeCallback = async (contentType: string, buffer: Buffer) => {
   if (contentType === 'image/svg+xml') {
-    const newBuffer = await sharp(buffer).png().toBuffer();
+    const newBuffer = await sharp(buffer).resize(DEFAULT_SVG_IMAGE_SIZE).png().toBuffer();
 
     return {
       contentType: 'image/png',


### PR DESCRIPTION
I see that samwilsn.eth's page looks kind of crap: https://www.gitpoap.io/p/samwilsn.eth
His image is really small: https://www.gitpoap.io/_next/image?url=https%3A%2F%2Fens-avatar-cache-prod.s3.us-east-2.amazonaws.com%2F0x00d3baf1080b1cfb5897225a21ecdcc25a1f4456&w=3840&q=100

Since SVGs are vector images we can resize them to be larger without loss of quality so this resizes the image to a large enough size for the site (500x500) before converting to PNG.