### PR TITLE
Fix: create claims for multiple tagged contributors

### DIFF
--- a/src/routes/claims.ts
+++ b/src/routes/claims.ts
@@ -521,7 +521,7 @@ claimsRouter.post(
 
       for (let contribution of contributions) {
         if (contribution === null) {
-          newClaims = [];
+          continue;
         } else if ('pullRequest' in contribution) {
           const newClaimsForContribution = await retrieveClaimsCreatedByPR(
             contribution.pullRequest.id,
@@ -575,7 +575,7 @@ claimsRouter.post(
 
       for (let contribution of contributions) {
         if (contribution === null) {
-          newClaims = [];
+          continue;
         } else if ('mention' in contribution) {
           const newClaimsForContribution = await retrieveClaimsCreatedByMention(
             contribution.mention.id,


### PR DESCRIPTION
## WHAT'S DONE
- fixed `gitpoap-bot/create` endpoint to be able to create claims for multiple tagged contributors