### PR TITLE
Fix backend dev errors due to POAP API Failure

### DIFF
--- a/src/external/poap.ts
+++ b/src/external/poap.ts
@@ -87,7 +87,7 @@ async function generatePOAPHeaders(hasBody: boolean) {
   const lastIndex = POAP_API_URL.lastIndexOf('/');
   const host = POAP_API_URL.substr(lastIndex + 1);
 
-  let base = {
+  const base = {
     Authorization: `Bearer ${await retrievePOAPToken()}`,
     'X-API-Key': POAP_API_KEY,
     Accept: 'application/json',
@@ -325,7 +325,17 @@ export async function retrieveUsersPOAPs(address: string) {
   return poapResponse;
 }
 
-export async function retrievePOAPTokenInfo(poapTokenId: string) {
+type POAPTokenInfoResponse = {
+  owner: string;
+  tokenId: string;
+  chain: string;
+  created: string;
+  event: POAPEventInfoResponse;
+};
+
+export async function retrievePOAPTokenInfo(
+  poapTokenId: string,
+): Promise<POAPTokenInfoResponse | null> {
   const logger = createScopedLogger('retrievePOAPTokenInfo');
 
   const cacheResponse = await context.redis.getValue(POAP_TOKEN_CACHE_PREFIX, poapTokenId);
@@ -368,7 +378,7 @@ export async function createPOAPEvent(
   city?: string,
   country?: string,
 ) {
-  let form = new FormData();
+  const form = new FormData();
 
   form.append('name', name);
   form.append('description', description);
@@ -386,7 +396,7 @@ export async function createPOAPEvent(
   form.append('email', email);
   form.append('requested_codes', num_requested_codes);
   form.append('private_event', 'false');
-  let headers = { ...form.getHeaders(), ...(await generatePOAPHeaders(false)) };
+  const headers = { ...form.getHeaders(), ...(await generatePOAPHeaders(false)) };
 
   return await makeGenericPOAPRequest(`${POAP_API_URL}/events`, 'POST', headers, form);
 }

--- a/src/lib/transfers.ts
+++ b/src/lib/transfers.ts
@@ -76,6 +76,11 @@ export async function checkIfClaimTransferred(claimId: number): Promise<string |
 
   const newData = await retrievePOAPTokenInfo(poapTokenId);
 
+  if (newData === null) {
+    logger.error(`Failed to retrieve POAP Token ID ${poapTokenId} from POAP API`);
+    return null;
+  }
+
   if (newData.owner !== claimData.address) {
     logger.info(`Found transferred GitPOAP Token ID: ${claimId}`);
 


### PR DESCRIPTION
Summary: 
This PR adds code to catch errors caused by poap api failures in dev ~ our `seed.db` file is a bit funky & is one of the root causes of this error.. but these changes should be useful regardless. 

Fixes the following: 
```bash
2022-09-16 18:35:54 [gitpoap-backend] DEBUG: (    186) retrievePOAPTokenInfo: POAP token 1234567894 info not in cache
2022-09-16 18:35:54 [gitpoap-backend] DEBUG: (    187) retrievePOAPToken: Using saved POAP API Token
2022-09-16 18:35:55 [gitpoap-backend] ERROR: (    184) makeGenericPOAPRequest: Bad response (404) for GET https://api.poap.tech/token/1234567894 from POAP API: {"statusCode":404,"error":"Not Found","message":"Token not found"}
2022-09-16 18:35:55 [gitpoap-backend] ERROR: unhandledRejection: Cannot read properties of null (reading 'owner')
TypeError: Cannot read properties of null (reading 'owner')
    at checkIfClaimTransferred (/Users/jaypuntham-baker/personal/git/gitpoap/gitpoap-backend/src/lib/transfers.ts:79:15)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
2022-09-16 18:35:55 [gitpoap-backend] ERROR: unhandledRejection: Cannot read properties of null (reading 'owner')
TypeError: Cannot read properties of null (reading 'owner')
    at checkIfClaimTransferred (/Users/jaypuntham-baker/personal/git/gitpoap/gitpoap-backend/src/lib/transfers.ts:79:15)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
2022-09-16 18:35:55 [gitpoap-backend] ERROR: (    188) makeGenericPOAPRequest: Bad response (404) for GET https://api.poap.tech/token/1234567894 from POAP API: {"statusCode":404,"error":"Not Found","message":"Token not found"}
2022-09-16 18:35:55 [gitpoap-backend] ERROR: unhandledRejection: Cannot read properties of null (reading 'owner')
TypeError: Cannot read properties of null (reading 'owner')
    at checkIfClaimTransferred (/Users/jaypuntham-baker/personal/git/gitpoap/gitpoap-backend/src/lib/transfers.ts:79:15)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
2022-09-16 18:35:55 [gitpoap-backend] ERROR: unhandledRejection: Cannot read properties of null (reading 'owner')
TypeError: Cannot read properties of null (reading 'owner')
    at checkIfClaimTransferred (/Users/jaypuntham-baker/personal/git/gitpoap/gitpoap-backend/src/lib/transfers.ts:79:15)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
^C
```