### PR TITLE
Ensure bot doesn't create PR-based claims on isPRBased=false

### DIFF
--- a/__tests__/unit/src/lib/bot.ts
+++ b/__tests__/unit/src/lib/bot.ts
@@ -107,7 +107,7 @@ describe('createClaimsForPR', () => {
     expect(mockedGetGithubUserByIdAsAdmin).toHaveBeenCalledWith(githubId);
 
     expect(mockedGetRepoByName).toHaveBeenCalledTimes(1);
-    expect(mockedGetRepoByName).toHaveBeenCalledWith(organization, repo);
+    expect(mockedGetRepoByName).toHaveBeenCalledWith(organization, repo, true);
 
     expect(mockedGetSingleGithubRepositoryPullAsAdmin).toHaveBeenCalledTimes(0);
   });
@@ -132,7 +132,7 @@ describe('createClaimsForPR', () => {
     expect(mockedGetGithubUserByIdAsAdmin).toHaveBeenCalledWith(githubId);
 
     expect(mockedGetRepoByName).toHaveBeenCalledTimes(1);
-    expect(mockedGetRepoByName).toHaveBeenCalledWith(organization, repo);
+    expect(mockedGetRepoByName).toHaveBeenCalledWith(organization, repo, true);
 
     expect(mockedGetSingleGithubRepositoryPullAsAdmin).toHaveBeenCalledTimes(1);
     expect(mockedGetSingleGithubRepositoryPullAsAdmin).toHaveBeenCalledWith(
@@ -177,7 +177,7 @@ describe('createClaimsForPR', () => {
     expect(mockedGetGithubUserByIdAsAdmin).toHaveBeenCalledWith(githubId);
 
     expect(mockedGetRepoByName).toHaveBeenCalledTimes(1);
-    expect(mockedGetRepoByName).toHaveBeenCalledWith(organization, repo);
+    expect(mockedGetRepoByName).toHaveBeenCalledWith(organization, repo, true);
 
     expect(mockedGetSingleGithubRepositoryPullAsAdmin).toHaveBeenCalledTimes(1);
     expect(mockedGetSingleGithubRepositoryPullAsAdmin).toHaveBeenCalledWith(
@@ -244,7 +244,7 @@ describe('createClaimsForPR', () => {
     expect(mockedGetGithubUserByIdAsAdmin).toHaveBeenCalledWith(githubId);
 
     expect(mockedGetRepoByName).toHaveBeenCalledTimes(1);
-    expect(mockedGetRepoByName).toHaveBeenCalledWith(organization, repo);
+    expect(mockedGetRepoByName).toHaveBeenCalledWith(organization, repo, undefined);
 
     expect(mockedGetSingleGithubRepositoryPullAsAdmin).toHaveBeenCalledTimes(1);
     expect(mockedGetSingleGithubRepositoryPullAsAdmin).toHaveBeenCalledWith(

--- a/src/lib/bot.ts
+++ b/src/lib/bot.ts
@@ -39,7 +39,11 @@ export async function createClaimsForPR(
     return BotCreateClaimsErrorType.BotUser;
   }
 
-  const repoData = await getRepoByName(organization, repo);
+  // We need to skip any GitPOAPs that are not PR-based if
+  // the bot called this endpoint because a PR was newly merged
+  let mustBePRBased: boolean | undefined = wasEarnedByMention ? undefined : true;
+
+  const repoData = await getRepoByName(organization, repo, mustBePRBased);
   if (repoData === null) {
     logger.warn(`Failed to find repo: "${organization}/${repo}"`);
     return BotCreateClaimsErrorType.RepoNotFound;

--- a/src/lib/repos.ts
+++ b/src/lib/repos.ts
@@ -92,7 +92,11 @@ export async function createRepoByGithubId(
   return await createRepoHelper(repoInfo, projectId);
 }
 
-export async function getRepoByName(owner: string, repo: string): Promise<RepoData | null> {
+export async function getRepoByName(
+  owner: string,
+  repo: string,
+  isPRBased?: boolean,
+): Promise<RepoData | null> {
   const logger = createScopedLogger('getRepoByName');
 
   const result = await context.prisma.repo.findMany({
@@ -109,6 +113,7 @@ export async function getRepoByName(owner: string, repo: string): Promise<RepoDa
           gitPOAPs: {
             where: {
               ongoing: true,
+              isPRBased,
               NOT: {
                 status: GitPOAPStatus.DEPRECATED,
               },


### PR DESCRIPTION
Currently if `gitpoap-bot` is added to a repo/org and some GitPOAPs in that project have `isPRBased === false`, the bot will still issue claims for the users. This fixes this issue.