### PR TITLE
Set AWS_PROFILE for public-api containers

### DIFF
--- a/aws/public-api-server.task-definition.json.j2
+++ b/aws/public-api-server.task-definition.json.j2
@@ -28,7 +28,7 @@
         },
         {
           "name": "AWS_PROFILE",
-          "value": "not-used-for-this-server"
+          "value": "docker-agent"
         },
         {
           "name": "NODE_ENV",


### PR DESCRIPTION
https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:log-groups/log-group/gitpoap-public-api-server-container/log-events/gitpoap-public-api-server$252Fgitpoap-public-api-server$252F6841fa3afbbc4617a17243603626593e