### PR TITLE
Add Token Related Fields to Email Table

### DIFF
--- a/prisma/factories.ts
+++ b/prisma/factories.ts
@@ -371,8 +371,18 @@ export class AddressFactory {
 }
 
 export class EmailFactory {
-  static create = async (email: string): Promise<Email> => {
-    const data: Prisma.EmailCreateInput = { emailAddress: email };
+  static create = async (
+    activeToken: string,
+    address: Prisma.EmailCreateInput['address'],
+    email: string,
+    tokenExpiresAt: string,
+  ): Promise<Email> => {
+    const data: Prisma.EmailCreateInput = {
+      activeToken,
+      address,
+      emailAddress: email,
+      tokenExpiresAt,
+    };
     const emailObj = await prisma.email.create({ data });
     logger.debug(`Creating email with id: ${emailObj.id}`);
 

--- a/prisma/migrations/20220929185844_add_token_fields_to_email/migration.sql
+++ b/prisma/migrations/20220929185844_add_token_fields_to_email/migration.sql
@@ -1,0 +1,31 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `emailId` on the `Address` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[addressId]` on the table `Email` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[activeToken]` on the table `Email` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `activeToken` to the `Email` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `addressId` to the `Email` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `tokenExpiresAt` to the `Email` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Address" DROP CONSTRAINT "Address_emailId_fkey";
+
+-- AlterTable
+ALTER TABLE "Address" DROP COLUMN "emailId";
+
+-- AlterTable
+ALTER TABLE "Email" ADD COLUMN     "activeToken" TEXT NOT NULL,
+ADD COLUMN     "addressId" INTEGER NOT NULL,
+ADD COLUMN     "isValidated" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "tokenExpiresAt" TIMESTAMP(3) NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Email_addressId_key" ON "Email"("addressId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Email_activeToken_key" ON "Email"("activeToken");
+
+-- AddForeignKey
+ALTER TABLE "Email" ADD CONSTRAINT "Email_addressId_fkey" FOREIGN KEY ("addressId") REFERENCES "Address"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -54,8 +54,7 @@ model Profile {
 model Address {
   id                Int                      @id @default(autoincrement())
   ethAddress        String                   @unique @db.VarChar(255)
-  emailId           Int?
-  email             Email?                   @relation(fields: [emailId], references: [id])
+  email             Email?
   createdAt         DateTime                 @default(now())
   updatedAt         DateTime                 @updatedAt
   githubUserId      Int?
@@ -71,12 +70,16 @@ model Address {
 }
 
 model Email {
-  id           Int       @id @default(autoincrement())
-  emailAddress String    @db.VarChar(255)
-  createdAt    DateTime  @default(now())
-  updatedAt    DateTime  @updatedAt
-  addresses    Address[]
-  claims       Claim[]
+  id             Int       @id @default(autoincrement())
+  emailAddress   String    @db.VarChar(255)
+  addressId      Int       @unique
+  address        Address   @relation(fields: [addressId], references: [id])
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+  claims         Claim[]
+  isValidated    Boolean   @default(false)
+  activeToken    String    @unique
+  tokenExpiresAt DateTime
 }
 
 model OrganizationMembership {

--- a/schema.gql
+++ b/schema.gql
@@ -690,7 +690,6 @@ input AddressWhereInput {
   NOT: [AddressWhereInput!]
   id: IntFilter
   ethAddress: StringFilter
-  emailId: IntNullableFilter
   email: EmailRelationFilter
   createdAt: DateTimeFilter
   updatedAt: DateTimeFilter
@@ -744,22 +743,30 @@ input EmailWhereInput {
   NOT: [EmailWhereInput!]
   id: IntFilter
   emailAddress: StringFilter
+  addressId: IntFilter
+  address: AddressRelationFilter
   createdAt: DateTimeFilter
   updatedAt: DateTimeFilter
-  addresses: AddressListRelationFilter
   claims: ClaimListRelationFilter
-}
-
-input AddressListRelationFilter {
-  every: AddressWhereInput
-  some: AddressWhereInput
-  none: AddressWhereInput
+  isValidated: BoolFilter
+  activeToken: StringFilter
+  tokenExpiresAt: DateTimeFilter
 }
 
 input ClaimListRelationFilter {
   every: ClaimWhereInput
   some: ClaimWhereInput
   none: ClaimWhereInput
+}
+
+input BoolFilter {
+  equals: Boolean
+  not: NestedBoolFilter
+}
+
+input NestedBoolFilter {
+  equals: Boolean
+  not: NestedBoolFilter
 }
 
 input UserRelationFilter {
@@ -989,16 +996,6 @@ input NestedEnumGitPOAPStatusFilter {
   not: NestedEnumGitPOAPStatusFilter
 }
 
-input BoolFilter {
-  equals: Boolean
-  not: NestedBoolFilter
-}
-
-input NestedBoolFilter {
-  equals: Boolean
-  not: NestedBoolFilter
-}
-
 input RedeemCodeListRelationFilter {
   every: RedeemCodeWhereInput
   some: RedeemCodeWhereInput
@@ -1103,6 +1100,12 @@ input GithubIssueRelationFilter {
   isNot: GithubIssueWhereInput
 }
 
+input AddressListRelationFilter {
+  every: AddressWhereInput
+  some: AddressWhereInput
+  none: AddressWhereInput
+}
+
 input ProfileRelationFilter {
   is: ProfileWhereInput
   isNot: ProfileWhereInput
@@ -1181,7 +1184,6 @@ enum SortOrder {
 input AddressOrderByWithRelationInput {
   id: SortOrder
   ethAddress: SortOrder
-  emailId: SortOrder
   email: EmailOrderByWithRelationInput
   createdAt: SortOrder
   updatedAt: SortOrder
@@ -1198,14 +1200,14 @@ input AddressOrderByWithRelationInput {
 input EmailOrderByWithRelationInput {
   id: SortOrder
   emailAddress: SortOrder
+  addressId: SortOrder
+  address: AddressOrderByWithRelationInput
   createdAt: SortOrder
   updatedAt: SortOrder
-  addresses: AddressOrderByRelationAggregateInput
   claims: ClaimOrderByRelationAggregateInput
-}
-
-input AddressOrderByRelationAggregateInput {
-  _count: SortOrder
+  isValidated: SortOrder
+  activeToken: SortOrder
+  tokenExpiresAt: SortOrder
 }
 
 input ClaimOrderByRelationAggregateInput {
@@ -1234,6 +1236,10 @@ input GithubIssueOrderByRelationAggregateInput {
 }
 
 input GithubMentionOrderByRelationAggregateInput {
+  _count: SortOrder
+}
+
+input AddressOrderByRelationAggregateInput {
   _count: SortOrder
 }
 
@@ -1454,7 +1460,6 @@ type Claim {
 type Address {
   id: Int!
   ethAddress: String!
-  emailId: Int
   createdAt: DateTime!
   updatedAt: DateTime!
   githubUserId: Int
@@ -1897,7 +1902,6 @@ input AddressWhereUniqueInput {
 enum AddressScalarFieldEnum {
   id
   ethAddress
-  emailId
   createdAt
   updatedAt
   githubUserId
@@ -1984,13 +1988,16 @@ type EventCount {
 type Email {
   id: Int!
   emailAddress: String!
+  addressId: Int!
   createdAt: DateTime!
   updatedAt: DateTime!
+  isValidated: Boolean!
+  activeToken: String!
+  tokenExpiresAt: DateTime!
   _count: EmailCount
 }
 
 type EmailCount {
-  addresses: Int!
   claims: Int!
 }
 


### PR DESCRIPTION
Summary:
This PR will enables email validation through the adition of fields: `validated`, `activeToken`, and `tokenExpiresAt`