### PR TITLE
fix: change the gitpoap-bot app_id to the correct value & add a failsafe

### DIFF
--- a/__tests__/unit/src/constants.test.ts
+++ b/__tests__/unit/src/constants.test.ts
@@ -1,0 +1,8 @@
+import { GITPOAP_BOT_APP_ID } from '../../../src/constants';
+
+describe('constants', () => {
+  it('GITPOAP_BOT_APP_ID should be the correct value', () => {
+    /* Ensure that when we do development, we don't accidentally commit the dev APP_ID */
+    expect(GITPOAP_BOT_APP_ID).toBe(209535);
+  });
+});

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,8 +13,7 @@ export const ADMIN_GITHUB_IDS = [
   19416312, // Aldo
 ];
 
-// export const GITPOAP_BOT_APP_ID = 209535;
-export const GITPOAP_BOT_APP_ID = 236807;
+export const GITPOAP_BOT_APP_ID = 209535;
 
 // The minimum number of redeem codes we need to maintain
 // for "ongoing" GitPOAPs. If we reach this threshold after


### PR DESCRIPTION
Summary: 
The app_id for the bot was changed inadvertently by me in a previous pull request for dev purposes. 

Here, we're changing the app_id back to the correct value & adding a test as a failsafe.. just to prevent this from happening again. 