### PR TITLE
Updates to Github auth connection DELETE

### DIFF
--- a/__tests__/unit/src/routes/github.ts
+++ b/__tests__/unit/src/routes/github.ts
@@ -255,6 +255,17 @@ describe('DELETE /github', () => {
       },
     });
 
+    /* Expect that the token is updated to remove the user */
+    expect(contextMock.prisma.authToken.update).toHaveBeenCalledTimes(1);
+    expect(contextMock.prisma.authToken.update).toHaveBeenCalledWith({
+      where: { id: authTokenId },
+      data: {
+        generation: { increment: 1 },
+        user: { disconnect: true },
+      },
+      select: { generation: true },
+    });
+
     expect(mockedRemoveGithubLoginForAddress).toHaveBeenCalledTimes(1);
     expect(mockedRemoveGithubLoginForAddress).toHaveBeenCalledWith(addressId);
   });

--- a/src/lib/authTokens.ts
+++ b/src/lib/authTokens.ts
@@ -1,5 +1,4 @@
 import { context } from '../context';
-import { upsertUser } from '../lib/users';
 import { JWT_EXP_TIME_SECONDS } from '../constants';
 import { sign } from 'jsonwebtoken';
 import { JWT_SECRET } from '../environment';

--- a/src/routes/github.ts
+++ b/src/routes/github.ts
@@ -130,15 +130,12 @@ githubRouter.delete('/', jwtWithAddress(), async function (req, res) {
   // Update the generation of the AuthToken (this must exist
   // since it was looked up within the middleware)
   const dbAuthToken = await context.prisma.authToken.update({
-    where: {
-      id: authTokenId,
-    },
+    where: { id: authTokenId },
     data: {
       generation: { increment: 1 },
+      user: { disconnect: true },
     },
-    select: {
-      generation: true,
-    },
+    select: { generation: true },
   });
 
   const userAuthTokens = generateAuthTokens(


### PR DESCRIPTION
Summary: 
This PR contains work that properly dissociates the github handle from the token when a user removes that connection from their address account