### PR TITLE
Script to count first X unique users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .env
 notes
 prisma/dbml
+*.csv

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "test:integration": "yarn docker:build-integration-tests && yarn docker:run-integration-tests",
     "test:quick-integration": "TEST_ENV=integration docker-compose up --no-deps --build integration-tests",
     "test:all": "yarn build && yarn test:unit && yarn test:integration",
-    "heat-up-ens-cache": "APP_NAME=heat-up-ens-cache ts-node-dev ./scripts/heat-up-ens-cache.ts"
+    "heat-up-ens-cache": "APP_NAME=heat-up-ens-cache ts-node-dev ./scripts/heat-up-ens-cache.ts",
+    "first-users": "APP_NAME=first-users ts-node-dev ./scripts/first-users.ts"
   },
   "devDependencies": {
     "@types/badgen": "^2.7.1",

--- a/scripts/first-users.ts
+++ b/scripts/first-users.ts
@@ -1,0 +1,85 @@
+require('dotenv').config();
+
+import 'reflect-metadata';
+import { createScopedLogger, updateLogLevel } from '../src/logging';
+import minimist from 'minimist';
+import { context } from '../src/context';
+import { ClaimStatus } from '@prisma/client';
+import { writeFile } from 'fs/promises';
+
+async function findFirstUsers(requestedCount: number) {
+  const logger = createScopedLogger('findFirstUsers');
+
+  const claims = await context.prisma.claim.findMany({
+    where: {
+      status: ClaimStatus.CLAIMED,
+    },
+    select: {
+      id: true,
+      mintedAt: true,
+      user: {
+        select: {
+          githubHandle: true,
+          githubId: true,
+        },
+      },
+    },
+    orderBy: {
+      mintedAt: 'asc',
+    },
+  });
+
+  logger.info(`Found ${claims.length} Claims`);
+
+  let resultContent = 'githubHandle,githubId,mintedAt\n';
+  let foundGithubIds = new Set<number>();
+
+  for (const claim of claims) {
+    if (!foundGithubIds.has(claim.user.githubId)) {
+      if (claim.mintedAt === null) {
+        logger.error(`Claim ID ${claim.id} has status CLAIMED but mintedAt is null`);
+        continue;
+      }
+
+      const mintedAt = claim.mintedAt.toISOString();
+
+      resultContent += `${claim.user.githubHandle},${claim.user.githubId},${mintedAt}\n`;
+
+      foundGithubIds.add(claim.user.githubId);
+
+      if (foundGithubIds.size === requestedCount) {
+        break;
+      }
+    }
+  }
+
+  if (foundGithubIds.size !== requestedCount) {
+    logger.warn(`There are only ${foundGithubIds.size} unique users!`);
+  } else {
+    logger.info(`Found the first ${requestedCount} unique users`);
+  }
+
+  await writeFile(`first-${requestedCount}-users.csv`, resultContent);
+}
+
+const main = async () => {
+  const logger = createScopedLogger('main');
+
+  const argv = minimist(process.argv.slice(2));
+
+  logger.info(`Command line args: ${JSON.stringify(argv)}`);
+
+  updateLogLevel(argv['level']);
+
+  if (!('_' in argv) || argv['_'].length !== 1) {
+    logger.error('A single number of users must be supplied as a command line argument');
+    process.exit(1);
+    return;
+  }
+
+  const count = parseInt(argv['_'][0], 10);
+
+  await findFirstUsers(count);
+};
+
+main();


### PR DESCRIPTION
This script ensures that we can select the first X users with GitPOAPs ordered by `mintedAt`. We can merge this after the CG changes go through so we can update after that, but I will run it on the `db-client` machine so we can get the current count (for 500).

CC: @nixorokish 