### PR TITLE
feat: allow for searching by email, but no emailAddress returned

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -78,7 +78,7 @@ model Address {
 model Email {
   id             Int       @id @default(autoincrement())
   // Hide email.emailAddress from generated resolvers
-  /// @TypeGraphQL.omit(output: true, input: true)
+  /// @TypeGraphQL.omit(output: true, input: false)
   emailAddress   String    @unique @db.VarChar(255)
   addressId      Int?      @unique
   address        Address?  @relation(fields: [addressId], references: [id])
@@ -89,6 +89,8 @@ model Email {
   // Hide email.activeToken from generated resolvers
   /// @TypeGraphQL.omit(output: true, input: true)
   activeToken    String?   @unique
+  // Hide email.activeToken from generated resolvers
+  /// @TypeGraphQL.omit(output: true, input: true)
   tokenExpiresAt DateTime?
 }
 

--- a/schema.gql
+++ b/schema.gql
@@ -774,13 +774,13 @@ input EmailWhereInput {
   OR: [EmailWhereInput!]
   NOT: [EmailWhereInput!]
   id: IntFilter
+  emailAddress: StringFilter
   addressId: IntNullableFilter
   address: AddressRelationFilter
   createdAt: DateTimeFilter
   updatedAt: DateTimeFilter
   claims: ClaimListRelationFilter
   isValidated: BoolFilter
-  tokenExpiresAt: DateTimeNullableFilter
 }
 
 input ClaimListRelationFilter {
@@ -1325,13 +1325,13 @@ input AddressOrderByWithRelationInput {
 
 input EmailOrderByWithRelationInput {
   id: SortOrder
+  emailAddress: SortOrder
   addressId: SortOrder
   address: AddressOrderByWithRelationInput
   createdAt: SortOrder
   updatedAt: SortOrder
   claims: ClaimOrderByRelationAggregateInput
   isValidated: SortOrder
-  tokenExpiresAt: SortOrder
 }
 
 input ClaimOrderByRelationAggregateInput {
@@ -2262,7 +2262,6 @@ type Email {
   createdAt: DateTime!
   updatedAt: DateTime!
   isValidated: Boolean!
-  tokenExpiresAt: DateTime
   _count: EmailCount
 }
 


### PR DESCRIPTION
Summary: 
For the check eligibility page, we want the ability to search by email, but we don't actually want `emailAddress` values returned for privacy reasons. 

This PR contains work to do that. 