### PR TITLE
Show Email value

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -80,7 +80,7 @@ model Address {
 model Email {
   id                     Int              @id @default(autoincrement())
   // Hide email.emailAddress from generated resolvers
-  /// @TypeGraphQL.omit(output: true, input: false)
+  /// @TypeGraphQL.omit(output: false, input: false)
   emailAddress           String           @unique @db.VarChar(255)
   addressId              Int?             @unique
   address                Address?         @relation(fields: [addressId], references: [id])

--- a/schema.gql
+++ b/schema.gql
@@ -1926,6 +1926,7 @@ type GitPOAPRequest {
 
 type Email {
   id: Int!
+  emailAddress: String!
   addressId: Int
   createdAt: DateTime!
   updatedAt: DateTime!


### PR DESCRIPTION
Summary: 
Show the email value in GQL output for now. 

we will prioritize adding an auth layer to prevent this & will likely use custom resolvers. 