### PR TITLE
Update RedeemCode validation script to delete codes and check addresses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 notes
 prisma/dbml
 *.csv
+*.txt

--- a/scripts/validate-codes.ts
+++ b/scripts/validate-codes.ts
@@ -5,7 +5,8 @@ import 'reflect-metadata';
 import { createScopedLogger, updateLogLevel } from '../src/logging';
 import minimist from 'minimist';
 import { context } from '../src/context';
-import { retrievePOAPCodes } from '../src/external/poap';
+import { retrievePOAPCodes, retrievePOAPsForEvent } from '../src/external/poap';
+import { ClaimStatus } from '@prisma/client';
 
 type CodeUsageMap = Record<string, boolean>;
 
@@ -37,6 +38,105 @@ async function generateCodeUsageMap(
   }
 
   return { codeUsageMap: usages, unusedCount };
+}
+
+async function attemptToFindGithubUserForAddress(ethAddress: string) {
+  return await context.prisma.claim.findFirst({
+    where: {
+      mintedAddress: { ethAddress },
+      NOT: { githubUserId: null },
+    },
+    select: {
+      githubUser: {
+        select: {
+          id: true,
+          githubHandle: true,
+        },
+      },
+    },
+  });
+}
+
+async function checkForMissingMints(gitPOAPId: number, poapEventId: number) {
+  const logger = createScopedLogger('checkForMissingMints');
+
+  const claimedClaimsInDB = await context.prisma.claim.findMany({
+    where: {
+      gitPOAPId,
+      status: ClaimStatus.CLAIMED,
+    },
+    select: {
+      id: true,
+      needsRevalidation: true,
+      mintedAddress: {
+        select: { ethAddress: true },
+      },
+    },
+  });
+
+  const claimedAddressesInDB = new Set<string>();
+  for (const claim of claimedClaimsInDB) {
+    if (claim.mintedAddress === null) {
+      logger.error(`Claim ID ${claim.id} has status CLAIMED but mintedAddress is null`);
+      continue;
+    }
+    claimedAddressesInDB.add(claim.mintedAddress.ethAddress);
+  }
+
+  logger.info(`Found ${claimedAddressesInDB.size} addresses with completed claims in DB`);
+
+  const poapsForEvent = await retrievePOAPsForEvent(poapEventId);
+  if (poapsForEvent === null) {
+    logger.error(`Failed to lookup POAPs for POAP Event ID ${poapEventId} via POAP API`);
+    return;
+  }
+
+  logger.info(`POAP API says there are ${poapsForEvent.length} POAPs minted`);
+
+  const poapAddresses = new Set<string>();
+  for (const poap of poapsForEvent) {
+    const poapOwner = poap.owner.id.toLowerCase();
+
+    poapAddresses.add(poapOwner);
+
+    if (!claimedAddressesInDB.has(poapOwner)) {
+      logger.error(`Our DB does not have an entry for ${poapOwner}`);
+
+      const githubUserData = await attemptToFindGithubUserForAddress(poapOwner);
+
+      if (githubUserData === null) {
+        logger.error(`Failed to find an associated GitHub user for ${poapOwner}`);
+        continue;
+      }
+
+      if (githubUserData.githubUser === null) {
+        logger.error(
+          'DB returned githubUser column that is null though we specifically requested it not to',
+        );
+        continue;
+      }
+
+      logger.info(
+        `GitHub user ${githubUserData.githubUser.githubHandle} (ID: ${githubUserData.githubUser.id}) claimed POAP ID ${poap.id} at '${poap.created}' with address '${poapOwner}'`,
+      );
+    }
+  }
+
+  for (const claim of claimedClaimsInDB) {
+    // Here we assume that mintedAddress is not null since we specifically requested it from DB
+    // and logged an error earlier
+    const mintedAddress = claim.mintedAddress?.ethAddress ?? '';
+
+    if (!poapAddresses.has(mintedAddress)) {
+      logger.error(
+        `The list of addresses holding the GitPOAP does not contain address ${mintedAddress}`,
+      );
+
+      if (claim.needsRevalidation) {
+        logger.info('Note that this address needs revalidation');
+      }
+    }
+  }
 }
 
 async function checkGitPOAPCodes(gitPOAPId: number) {
@@ -75,7 +175,7 @@ async function checkGitPOAPCodes(gitPOAPId: number) {
     },
   });
 
-  logger.info(`There are ${gitPOAPCodes} "unused" codes in our database`);
+  logger.info(`There are ${gitPOAPCodes.length} "unused" codes in our database`);
 
   let notFound = 0;
   let alreadyUsed = 0;
@@ -87,6 +187,10 @@ async function checkGitPOAPCodes(gitPOAPId: number) {
     } else if (codeUsageMap[redeemCode.code]) {
       logger.error(`RedeemCode ID ${redeemCode.id} was already used!`);
       ++alreadyUsed;
+
+      await context.prisma.redeemCode.delete({
+        where: { id: redeemCode.id },
+      });
     }
   }
 
@@ -101,6 +205,8 @@ async function checkGitPOAPCodes(gitPOAPId: number) {
   } else {
     logger.error(`GitPOAP ID ${gitPOAPId} has FAILED validation`);
   }
+
+  await checkForMissingMints(gitPOAPId, gitPOAP.poapEventId);
 }
 
 const main = async () => {
@@ -112,14 +218,20 @@ const main = async () => {
 
   updateLogLevel(argv['level']);
 
-  if (!('_' in argv) || argv['_'].length !== 1) {
-    logger.error('The GitPOAP ID must be supplied as a command line argument');
-    process.exit(1);
+  let gitPOAPIds: number[] = [];
+  if ('only' in argv) {
+    gitPOAPIds = [argv['only']].concat(argv['_']).map((id: string) => parseInt(id, 10));
+
+    logger.info(`Running only on GitPOAP IDs: ${gitPOAPIds}`);
+  } else {
+    logger.info('Running on all GitPOAPs');
+
+    gitPOAPIds = (await context.prisma.gitPOAP.findMany({ select: { id: true } })).map(gp => gp.id);
   }
 
-  const gitPOAPId = parseInt(argv['_'][0], 10);
-
-  await checkGitPOAPCodes(gitPOAPId);
+  for (const gitPOAPId of gitPOAPIds) {
+    await checkGitPOAPCodes(gitPOAPId);
+  }
 };
 
 void main();

--- a/src/external/poap.ts
+++ b/src/external/poap.ts
@@ -421,7 +421,7 @@ async function retrievePagedPOAPsForEvent(
   const offset = perPage * page;
 
   const poapResponse = await makePOAPRequest(
-    `${POAP_API_URL}/event/${poapEventId}/poaps?page=${page}&offset=${offset}`,
+    `${POAP_API_URL}/event/${poapEventId}/poaps?limit=${perPage}&offset=${offset}`,
     'GET',
     null,
   );


### PR DESCRIPTION
This now removes RedeemCodes in the DB that were already claimed and cross-references the POAP API address vs the `mintedAddress` in our DB.