### PR TITLE
Claim Endpoint Auth

### DIFF
--- a/src/external/slack.ts
+++ b/src/external/slack.ts
@@ -60,13 +60,17 @@ function createGitPOAPLinkForClaim(gitPOAPId: number, gitPOAPName: string) {
 /** -- Use-case specific slack messages -- **/
 export const sendInternalClaimMessage = async (
   claims: FoundClaim[],
-  githubHandle: string,
   address: string,
+  githubHandle: string | null,
 ) => {
   const profileLink = `<${GITPOAP_URL}/p/${address}|GitPOAP Profile>`;
   const etherscanLink = `<https://etherscan.io/address/${address}|${shortenAddress(address)}>`;
-  const githubLink = createGithubUserLink(githubHandle);
-  let msg = `💸 [${profileLink}]: GitHub user ${githubLink} with address ${etherscanLink} claimed new GitPOAP(s)! 🥳`;
+  let msg = githubHandle
+    ? `💸 [${profileLink}]: GitHub user ${createGithubUserLink(
+        githubHandle,
+      )} with address ${etherscanLink} claimed new GitPOAP(s)! 🥳`
+    : `💸 [${profileLink}]: Address ${etherscanLink} claimed new GitPOAP(s)! 🥳`;
+
   for (const claim of claims) {
     msg += `\n* ${createGitPOAPLinkForClaim(claim.gitPOAPId, claim.gitPOAPName)}`;
   }

--- a/src/routes/organizations.ts
+++ b/src/routes/organizations.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { jwtWithAddress } from '../middleware/auth';
+import { jwtWithGitHubOAuth } from '../middleware/auth';
 import { getGithubOrganizationAdmins } from '../external/github';
 import { UpdateOrganizationSchema } from '../schemas/organizations';
 import { context } from '../context';
@@ -8,7 +8,7 @@ import { getRequestLogger } from '../middleware/loggingAndTiming';
 
 export const organizationsRouter = Router();
 
-organizationsRouter.post('/', jwtWithAddress(), async function (req, res) {
+organizationsRouter.post('/', jwtWithGitHubOAuth(), async function (req, res) {
   const logger = getRequestLogger(req);
 
   const schemaResult = UpdateOrganizationSchema.safeParse(req.body);


### PR DESCRIPTION
Summary: 
Switch the `POST /claims` endpoint to use address-centric auth