### PR TITLE
Add additional tests for userClaims

### DIFF
--- a/__tests__/integration/src/graphql/resolvers/claims.ts
+++ b/__tests__/integration/src/graphql/resolvers/claims.ts
@@ -24,22 +24,44 @@ describe('CustomClaimResolver', () => {
     expect(data.lastMonthClaims).toEqual(1);
   });
 
-  it('userClaims', async () => {
+  it('userClaims - githubHandle', async () => {
     const data = await client.request(gql`
-      {
-        userClaims(address: "${ADDRESSES.jay}") {
-          claim {
-            id
-          }
-          event {
-            name
-          }
-        }
-      }
+      { userClaims(address: "${ADDRESSES.jay}") { claim { id } } }
     `);
 
     // GitPOAP ID 5 doesn't have any claim codes or else this would be 6
     // and include Claim ID 18
     expect(data.userClaims).toHaveLength(5);
+    expect(data.userClaims).toContainEqual({ claim: { id: 22 } });
+    expect(data.userClaims).toContainEqual({ claim: { id: 26 } });
+    expect(data.userClaims).toContainEqual({ claim: { id: 30 } });
+    expect(data.userClaims).toContainEqual({ claim: { id: 34 } });
+    expect(data.userClaims).toContainEqual({ claim: { id: 38 } });
+  });
+
+  it('userClaims - email', async () => {
+    const data = await client.request(gql`
+      { userClaims(address: "${ADDRESSES.random}") { claim { id } } }
+    `);
+
+    expect(data.userClaims).toHaveLength(1);
+    expect(data.userClaims).toContainEqual({ claim: { id: 44 } });
+  });
+
+  it('userClaims - address', async () => {
+    const data = await client.request(gql`
+      { userClaims(address: "${ADDRESSES.random2}") { claim { id } } }
+    `);
+
+    expect(data.userClaims).toHaveLength(1);
+    expect(data.userClaims).toContainEqual({ claim: { id: 45 } });
+  });
+
+  it('userClaims - unknown address', async () => {
+    const data = await client.request(gql`
+      { userClaims(address: "${'0x4' + ADDRESSES.random2.substr(3)}") { claim { id } } }
+    `);
+
+    expect(data.userClaims).toHaveLength(0);
   });
 });

--- a/prisma/constants.ts
+++ b/prisma/constants.ts
@@ -8,6 +8,7 @@ export const ADDRESSES = {
   tyler: '0x8404DDF7ed9Cce1EFDC14f3Af4c8eD0015d28937'.toLowerCase(),
   kayleen: '0x04c0cD38B8c203b14ef2b7B8d736D69B938AFF71'.toLowerCase(),
   random: '0x89dab21047e6de0e77deee5f4f286d72be50b942'.toLowerCase(),
+  random2: '0x99dab21047e6de0e77defe5f4f286d72be50b942'.toLowerCase(),
 };
 
 export const GH_HANDLES = {

--- a/prisma/factories.ts
+++ b/prisma/factories.ts
@@ -424,15 +424,23 @@ export class RedeemCodeFactory {
 }
 
 export class AddressFactory {
-  static create = async (address: string, githubUserId?: number): Promise<Address> => {
-    const data: Prisma.AddressUncheckedCreateInput = {
-      ethAddress: address,
-      githubUserId,
+  static create = async (
+    ethAddress: string,
+    githubUserId?: number,
+    emailId?: number,
+    ensName?: string,
+  ): Promise<Address> => {
+    const githubUser = githubUserId ? { connect: { id: githubUserId } } : undefined;
+    const email = emailId ? { connect: { id: emailId } } : undefined;
+
+    const data: Prisma.AddressCreateInput = {
+      ethAddress,
+      githubUser,
+      email,
+      ensName,
     };
     const addressResult = await prisma.address.create({ data });
-    logger.debug(
-      `Creating address with id: ${addressResult.id} & ethAddress: ${addressResult.ethAddress}`,
-    );
+    logger.debug(`Creating address with id: ${addressResult.id} & ethAddress: ${ethAddress}`);
 
     return addressResult;
   };

--- a/prisma/seed-test.ts
+++ b/prisma/seed-test.ts
@@ -62,6 +62,13 @@ export const seed = async () => {
   const burz2 = await GithubUserFactory.create(6, 'burzzzzz');
   const kayleen = await GithubUserFactory.create(GH_IDS.kayleen, GH_HANDLES.kayleen);
 
+  /* Create email addresses */
+  const teamEmail = await EmailFactory.create(TEAM_EMAIL);
+  const jayEmail = await EmailFactory.create('jay@gitpoap.io');
+  const unvalidatedEmail = await EmailFactory.create('unvalidated@gitpoap.io', undefined, 'testtoken1', false, DateTime.now().plus({ day: 1 }).toJSDate());
+  const expiredEmail = await EmailFactory.create('expired@gitpoap.io', undefined, 'testtoken2', false, DateTime.now().minus({ day: 1 }).toJSDate());
+  const validatedEmail = await EmailFactory.create('validated@gitpoap.io', undefined, 'testtoken3', true, DateTime.now().minus({ day: 1 }).toJSDate());
+
   /* Create Address */
   const addressJay = await AddressFactory.create(ADDRESSES.jay, jay.id);
   const addressBurz = await AddressFactory.create(ADDRESSES.burz, burz.id);
@@ -71,14 +78,8 @@ export const seed = async () => {
   const addressAldo = await AddressFactory.create(ADDRESSES.aldo, aldo.id);
   const addressTyler = await AddressFactory.create(ADDRESSES.tyler, tyler.id);
   const addressKayleen = await AddressFactory.create(ADDRESSES.kayleen, kayleen.id);
-  const addressRandom1 = await AddressFactory.create(ADDRESSES.random);
-
-  /* Create email addresses */
-  const teamEmail = await EmailFactory.create(TEAM_EMAIL);
-  const jayEmail = await EmailFactory.create('jay@gitpoap.io');
-  const unvalidatedEmail = await EmailFactory.create('unvalidated@gitpoap.io', undefined, 'testtoken1', false, DateTime.now().plus({ day: 1 }).toJSDate());
-  const expiredEmail = await EmailFactory.create('expired@gitpoap.io', undefined, 'testtoken2', false, DateTime.now().minus({ day: 1 }).toJSDate());
-  const validatedEmail = await EmailFactory.create('validated@gitpoap.io', undefined, 'testtoken3', true, DateTime.now().minus({ day: 1 }).toJSDate());
+  const addressRandom1 = await AddressFactory.create(ADDRESSES.random, undefined, teamEmail.id);
+  const addressRandom2 = await AddressFactory.create(ADDRESSES.random2);
 
   /* Create Projects */
   const frontendProject = await ProjectFactory.create();
@@ -275,6 +276,10 @@ export const seed = async () => {
   // GitPOAP 18 - Deprecated
   const claim42 = await ClaimFactory.create(gitpoap18.id, burz.id, ClaimStatus.CLAIMED, addressBurz.id, '77777', DateTime.utc(2019, 12, 11).toJSDate());
   const claim43 = await ClaimFactory.create(gitpoap18.id, kayleen.id, ClaimStatus.CLAIMED, addressKayleen.id, '77778', DateTime.utc(2019, 12, 11).toJSDate());
+
+  // GitPOAP 9 - Other claim types
+  const claim44 = await ClaimFactory.createForEmail(gitpoap9.id, teamEmail.id);
+  const claim45 = await ClaimFactory.createForEthAddress(gitpoap9.id, addressRandom2.id);
 
   /* Create Profiles */
   const profile1 = await ProfileFactory.create(addressColfax.id, 'I like brisket.');


### PR DESCRIPTION
This fixes one issue where the Address record didn't exist it would return all claims (I don't think this was possible, though, anyways) as well as removes one redundancy since it was searching on both `ethAddress` and `ensName` though they should be on the same record.

I am writing the `POST /claims` unit tests next, but I think we should get this out.