### PR TITLE
Remove circular objects in errorHandler stringify

### DIFF
--- a/src/middleware/error.ts
+++ b/src/middleware/error.ts
@@ -6,7 +6,7 @@ import { captureException } from '../lib/sentry';
 function circularReplacer() {
   const objectsAlreadyVisited = new WeakSet();
 
-  return (key, value) => {
+  return (key: any, value: any) => {
     if (typeof value === 'object' && value !== null) {
       if (objectsAlreadyVisited.has(value)) {
         return '[Circular]';


### PR DESCRIPTION
This will no longer visit an object again during `JSON.stringify` in the `errorHandler` and instead print out `[Circular]`.

CC: @tyler415git 