### PR TITLE
feat: make github handle lookup insensitive

### DIFF
--- a/src/public-api/v1/index.ts
+++ b/src/public-api/v1/index.ts
@@ -135,6 +135,7 @@ v1Router.get('/github/user/:githubHandle/gitpoaps', async function (req, res) {
       githubUser: {
         githubHandle: {
           equals: req.params.githubHandle,
+          mode: 'insensitive',
         },
       },
       status,


### PR DESCRIPTION
Summary: 
Make github handle lookup insensitive on public-api