### PR TITLE
Fix issue with CGs not appearing in userPOAPs

### DIFF
--- a/src/lib/contributions.ts
+++ b/src/lib/contributions.ts
@@ -13,6 +13,10 @@ export async function countContributionsForClaim(
   repos: { id: number }[],
   gitPOAP: { year: number; isPRBased: boolean },
 ): Promise<number> {
+  if (repos.length === 0) {
+    return 0;
+  }
+
   const repoIds: number[] = repos.map(r => r.id);
 
   const dateRange = {


### PR DESCRIPTION
Noticed this on my page since the Launch Contributor GitPOAP wasn't appearing since `gitPOAP.githubUserId === null`.

Site: https://www.gitpoap.io/p/burz.eth
GQL: https://api.gitpoap.io/graphql?query=%7B%0A%20%20userPOAPs(address%3A%20%22burz.eth%22)%20%7B%0A%20%20%20%20totalGitPOAPs%0A%20%20%20%20gitPOAPs%20%7B%0A%20%20%20%20%20%20event%20%7B%0A%20%20%20%20%20%20%20%20name%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A

Note that I've also removed the logic to stop adding colored borders if they haven't set `profile.githubHandle` since we aren't following that paradigm anymore anyways.