### PR TITLE
Pre-download most db-migrator packages in image

### DIFF
--- a/aws/db-migrator/Dockerfile
+++ b/aws/db-migrator/Dockerfile
@@ -23,8 +23,7 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
 RUN curl -L https://raw.githubusercontent.com/tj/n/master/bin/n -o n && \
   bash n install 16.15.1 && \
   rm n
-
-RUN npm install --location=global npm@8.19.2 yarn
+RUN npm install --location=global npm@9.1.2 yarn
 
 COPY cdk-lambda-bash/bootstrap /var/runtime/bootstrap
 COPY cdk-lambda-bash/function.sh /var/task/function.sh
@@ -42,6 +41,9 @@ WORKDIR /var/repos
 RUN git clone https://${GITHUB_OAUTH_TOKEN}@github.com/gitpoap/gitpoap-backend.git
 WORKDIR /var/repos/gitpoap-backend
 RUN git checkout ${REPO_BRANCH}
+
+# prefetch as many packages as possible
+RUN yarn
 
 COPY run-migrations.sh /var/task/main.sh
 RUN chmod +x /var/task/main.sh


### PR DESCRIPTION
This should speed up most migrations by reducing the amount of downloading/building that needs to be done each migration.

Note that I've already updated the lambdas on AWS with this.