### PR TITLE
Add gitpoap.eth to Staff Addresses

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,7 +21,7 @@ export const STAFF_ADDRESSES = [
   '0xa4c58baf393ebf3a281a4bc6152ae084e63dc28e', // Kayla
   '0x02738d122e0970aaf8deadf0c6a217a1923e1e99', // Aldo
   '0xe078c3bdee620829135e1ab526be860498b06339', // Tyler
-  '0x9B6e1a427be7A9456f4aF18eeaa354ccabF3980a', // gitpoap.eth
+  '0x9b6e1a427be7a9456f4af18eeaa354ccabf3980a', // gitpoap.eth
 ];
 
 export const GITPOAP_BOT_APP_ID = 209535;


### PR DESCRIPTION
Adds `gitpoap.eth` (`0x9B6e1a427be7A9456f4aF18eeaa354ccabF3980a`) to staff addresses list
https://app.ens.domains/name/gitpoap.eth/details