### PR TITLE
Run post processing on MINTING Claims on startup

### DIFF
--- a/__tests__/integration/src/graphql/resolvers/claims.ts
+++ b/__tests__/integration/src/graphql/resolvers/claims.ts
@@ -84,5 +84,5 @@ describe('CustomClaimResolver', () => {
     });
 
     expect(data.userClaims).toHaveLength(0);
-  });
+  }, 10000);
 });

--- a/__tests__/unit/src/routes/claims.ts
+++ b/__tests__/unit/src/routes/claims.ts
@@ -1075,7 +1075,9 @@ describe('POST /claims', () => {
     );
 
     expect(mockedRunClaimsPostProcessing).toHaveBeenCalledTimes(1);
-    expect(mockedRunClaimsPostProcessing).toHaveBeenCalledWith(claimIds, [redeemCode]);
+    expect(mockedRunClaimsPostProcessing).toHaveBeenCalledWith([
+      { id: claimIds[0], qrHash: redeemCode },
+    ]);
   });
 
   it('Succeeds on multiple claims when one fails', async () => {
@@ -1163,6 +1165,8 @@ describe('POST /claims', () => {
     );
 
     expect(mockedRunClaimsPostProcessing).toHaveBeenCalledTimes(1);
-    expect(mockedRunClaimsPostProcessing).toHaveBeenCalledWith([claimId], [redeemCode]);
+    expect(mockedRunClaimsPostProcessing).toHaveBeenCalledWith([
+      { id: claimId, qrHash: redeemCode },
+    ]);
   });
 });

--- a/src/routes/claims.ts
+++ b/src/routes/claims.ts
@@ -192,7 +192,13 @@ claimsRouter.post('/', jwtWithAddress(), async function (req, res) {
     invalid: invalidClaims,
   });
 
-  await runClaimsPostProcessing(claimedIds, qrHashes);
+  // Run in the background
+  void runClaimsPostProcessing(
+    claimedIds.map((id, i) => ({
+      id,
+      qrHash: qrHashes[i],
+    })),
+  );
 });
 
 claimsRouter.post('/create', jwtWithStaffOAuth(), async function (req, res) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,6 +20,7 @@ import minimist from 'minimist';
 import { startMetricsServer } from './metrics';
 import { setupApp } from './app';
 import { startBatchProcesses } from './batchProcessing';
+import { runStartupClaimsPostProcessing } from './lib/claims';
 
 const main = async () => {
   const logger = createScopedLogger('main');
@@ -58,6 +59,7 @@ const main = async () => {
   startMetricsServer();
 
   void startBatchProcesses();
+  void runStartupClaimsPostProcessing();
 };
 
 void main();


### PR DESCRIPTION
This has been on my backlist for a while, but now it's necessary since we have multiple [Claims stuck in `MINTING`](https://api.gitpoap.io/graphql?query=%7B%0A%20%20claims(where%3A%20%7Bstatus%3A%20%7Bequals%3A%20MINTING%7D%7D)%20%7B%0A%20%20%20%20id%0A%20%20%20%20poapTokenId%0A%20%20%20%20mintedAddress%20%7B%0A%20%20%20%20%20%20ethAddress%0A%20%20%20%20%7D%0A%20%20%20%20status%0A%20%20%20%20updatedAt%0A%20%20%20%20gitPOAP%20%7B%0A%20%20%20%20%20%20project%20%7B%0A%20%20%20%20%20%20%20%20repos%20%7B%0A%20%20%20%20%20%20%20%20%20%20name%0A%20%20%20%20%20%20%20%20%20%20organization%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20name%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20poapEventId%0A%20%20%20%20%7D%0A%20%20%20%20githubUser%20%7B%0A%20%20%20%20%20%20githubHandle%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A) and I can't fix them using the [method I used to](https://api.poap.xyz/actions/scan/0xd70804463bb2760c3384fc87bbe779e3d91bab3a) since POAP seems to have blocked access to their API via a web-browser (frankly understandable).