### PR TITLE
Upgrade TS to 4.9.4

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },
-  "eslint.validate": ["typescript"]
+  "eslint.validate": ["typescript"],
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "supertest": "^6.2.4",
     "ts-jest": "^28.0.4",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^4.7.4"
+    "typescript": "^4.9.4"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.142.0",

--- a/src/external/github.ts
+++ b/src/external/github.ts
@@ -27,9 +27,11 @@ export type OctokitPullItem = OctokitResponseData<PullsAPI['get']>;
 
 export type OctokitRepoItem = OctokitResponseData<ReposAPI['get']>;
 
-export type OctokitResponseData<T> = T extends (...arg0: any) => Promise<any>
-  ? Awaited<ReturnType<T>>['data']
-  : T;
+export type OctokitResponseData<T> = T extends (...args: any[]) => Promise<infer U>
+  ? U extends { data: unknown }
+    ? U['data']
+    : never
+  : never;
 
 async function responseHandler<T>(responsePromise: Promise<any>): Promise<T | null> {
   const logger = createScopedLogger('responseHandler');

--- a/yarn.lock
+++ b/yarn.lock
@@ -8569,10 +8569,10 @@ typegraphql-prisma@^0.21.5:
     ts-morph "^15.1.0"
     tslib "^2.4.0"
 
-typescript@^4.7.4:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+typescript@^4.9.4:
+  version "4.9.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
+  integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Summary: 
- Upgrade TS to the latest version `4.9.4` and fix a few type errors as a result. 
- Additionally, set vscode to use the installed TS instead of the default vscode TS.
