### PR TITLE
Remove `isOngoing: true` requirement from getRepoByName

### DIFF
--- a/src/lib/repos.ts
+++ b/src/lib/repos.ts
@@ -100,7 +100,6 @@ export async function getRepoByName(
         select: {
           gitPOAPs: {
             where: {
-              isOngoing: true,
               isPRBased,
               NOT: {
                 poapApprovalStatus: GitPOAPStatus.DEPRECATED,


### PR DESCRIPTION
This is only used in `src/lib/bot.ts` and obviously (now it's obvious at least...) we need to be able to issue on older years (which are by definition not `isOngoing`).

CC: @tyler415git 