### PR TITLE
Slack claim-by-mention alert should use GitPOAP.id

### DIFF
--- a/src/external/slack.ts
+++ b/src/external/slack.ts
@@ -187,7 +187,7 @@ export async function sendInternalClaimByMentionMessage(
     }
 
     const earnerLink = createGithubUserLink(claim.githubUser.githubHandle);
-    const gitPOAPLink = createGitPOAPLinkForClaim(claim.id, claim.gitPOAP.name);
+    const gitPOAPLink = createGitPOAPLinkForClaim(claim.gitPOAP.id, claim.gitPOAP.name);
     msg += `\n* GitHub User: ${earnerLink} earned ${gitPOAPLink}`;
   }
 


### PR DESCRIPTION
Not the cause of the problem, but this should be using the GitPOAP ID for the links