### PR TITLE
Fix headers arg location for graphiql

### DIFF
--- a/src/graphql/graphiql.ts
+++ b/src/graphql/graphiql.ts
@@ -64,8 +64,6 @@ export function renderGraphiQL() {
           fetcher: GraphiQL.createFetcher(
             {
               url: 'https://api.gitpoap.io/graphql',
-            },
-            {
               headers: { Authorization: 'Bearer null' },
             },
           ),


### PR DESCRIPTION
I can see this fixes the issue on localhost. I think I had originally read an older version of the docs which lead to this issue