### PR TITLE
Convert route not found

### DIFF
--- a/src/middleware/routeNotFound.ts
+++ b/src/middleware/routeNotFound.ts
@@ -3,7 +3,7 @@ import { getRequestLogger } from './loggingAndTiming';
 
 export const routeNotFoundHandler: RequestHandler = (req, res) => {
   // Note that the request logger already prints out the route
-  getRequestLogger(req).error(`Unknown route called!`);
+  getRequestLogger(req).warn('Unknown route called!');
 
   return res.status(404).send({
     msg: `Route ${req.method} ${req.path} not found!`,


### PR DESCRIPTION
Summary: 
`logger.error` now automatically dispatches messages to sentry. This PR converts the logger to use `warn` when a user hits a route that doesn't exist. Prevents it from getting to Sentry