### PR TITLE
Allow backloading after a specific merged at date

### DIFF
--- a/src/lib/pullRequests.ts
+++ b/src/lib/pullRequests.ts
@@ -253,7 +253,7 @@ export async function backloadGithubPullRequestData(repoId: number) {
 }
 
 // This should only be used by our background processes
-export async function getGithubRepositoryPullsMergedAfter(
+async function getGithubRepositoryPullsMergedAfter(
   org: string,
   repo: string,
   mergedAfter: DateTime,
@@ -341,6 +341,8 @@ export async function backloadGithubPullRequestDataForPRsMergedAfter(
     repoInfo.name,
     mergedAfter,
   );
+
+  logger.info(`Found ${prData.length} merged PRs after ${mergedAfter}`);
 
   // Handle all the PRs individually (and sequentially)
   for (const pr of prData) {


### PR DESCRIPTION
This PR updates the PR backloading script to allow backloading of PRs starting at some date in the past. This significantly improves the speed of fixing our data if something went wrong with our backloading/Claim creation at a certain time (minutes instead of *multiple hours*).