### PR TITLE
Fix; sendInternalClaimByMentionMessage

### DIFF
--- a/src/external/slack.ts
+++ b/src/external/slack.ts
@@ -191,5 +191,5 @@ export async function sendInternalClaimByMentionMessage(
     msg += `\n* GitHub User: ${earnerLink} earned ${gitPOAPLink}`;
   }
 
-  await sendSlackMessage(msg, CHANNELS.gitpoap.claimByMentionsAlerts);
+  await sendSlackMessage(msg, CHANNELS.gitpoap.claimByMentionAlerts);
 }


### PR DESCRIPTION
## WHAT'S DONE
- Fixed channel id in sendInternalClaimByMentionMessage in order to solve the sentry issue below

https://sentry.io/organizations/gitpoap/issues/3840597199/?project=6581819&referrer=slack#exception

