### PR TITLE
🗞️ Update Auth0 URL and API Audience for POAP API

### DIFF
--- a/aws/public-api-server.task-definition.json.j2
+++ b/aws/public-api-server.task-definition.json.j2
@@ -40,7 +40,7 @@
         },
         {
           "name": "POAP_AUTH_URL",
-          "value": "https://poapauth.auth0.com"
+          "value": "https://auth.accounts.poap.xyz"
         },
         {
           "name": "GITHUB_URL",

--- a/aws/server.task-definition.json.j2
+++ b/aws/server.task-definition.json.j2
@@ -36,7 +36,7 @@
         },
         {
           "name": "POAP_AUTH_URL",
-          "value": "https://poapauth.auth0.com"
+          "value": "https://auth.accounts.poap.xyz"
         },
         {
           "name": "GITHUB_URL",

--- a/src/external/poap.ts
+++ b/src/external/poap.ts
@@ -46,7 +46,7 @@ async function retrievePOAPToken(): Promise<string | null> {
   const poapResponse = await fetch(`${POAP_AUTH_URL}/oauth/token`, {
     method: 'POST',
     body: JSON.stringify({
-      audience: 'gitpoap',
+      audience: 'https://api.poap.tech/',
       grant_type: 'client_credentials',
       client_id: POAP_CLIENT_ID,
       client_secret: POAP_CLIENT_SECRET,

--- a/src/external/poap.ts
+++ b/src/external/poap.ts
@@ -46,7 +46,7 @@ async function retrievePOAPToken(): Promise<string | null> {
   const poapResponse = await fetch(`${POAP_AUTH_URL}/oauth/token`, {
     method: 'POST',
     body: JSON.stringify({
-      audience: 'https://api.poap.tech/',
+      audience: 'https://api.poap.tech',
       grant_type: 'client_credentials',
       client_id: POAP_CLIENT_ID,
       client_secret: POAP_CLIENT_SECRET,


### PR DESCRIPTION
## Update Auth0 URL and API Audience for POAP API

### This PR implements two main changes to maintain compatibility with the POAP API:

1. Update Auth0 base URL:
   - Old: https://poapauth.auth0.com/oauth/token
   - New: https://auth.accounts.poap.xyz/

2. Update API Audience name:
   - Old: [Previous audience name]
   - New: https://api.poap.tech/

These changes are necessary to continue using the POAP API. Please review and test to ensure proper functionality.